### PR TITLE
View model resilience

### DIFF
--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -18,6 +18,12 @@ struct EventContainerView: View {
     }
 
     var body: some View {
+        // NOTE: For as long as https://github.com/matrix-org/matrix-ios-sdk/pull/843
+        // remains unresolved keep in mind that
+        // `.keyVerificationStart`, `.keyVerificationAccept`, `.keyVerificationKey`,
+        // `.keyVerificationMac`, `.keyVerificationCancel` & `.reaction`
+        // may get wrongly recognized as `.custom(…)`, instead.
+        // FIXME: Remove comment when linked bug fix has been merged.
         switch MXEventType(identifier: event.type) {
         case .roomMessage:
             guard !event.isRedactedEvent() else {

--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -43,21 +43,30 @@ struct EventContainerView: View {
                 newEvent = edits.last ?? event
             }
 
-            // FIXME: remove
-            // swiftlint:disable:next force_try
-            let messageModel = try! MessageViewModel(event: newEvent,
-                                                     reactions: reactions,
-                                                     showSender: showSender)
-            return AnyView(
-                MessageView(
-                    model: .constant(messageModel),
-                    contextMenuModel: contextMenuModel,
-                    connectedEdges: connectedEdges,
-                    isEdited: event.contentHasBeenEdited()
+            do {
+                let messageModel = try MessageViewModel(
+                    event: newEvent,
+                    reactions: reactions,
+                    showSender: showSender
                 )
-                .padding(.top, topPadding)
-                .padding(.bottom, bottomPadding)
-            )
+                return AnyView(
+                    MessageView(
+                        model: .constant(messageModel),
+                        contextMenuModel: contextMenuModel,
+                        connectedEdges: connectedEdges,
+                        isEdited: event.contentHasBeenEdited()
+                    )
+                    .padding(.top, topPadding)
+                    .padding(.bottom, bottomPadding)
+                )
+            } catch let error as MessageViewModel.Error {
+                switch error {
+                case .invalidEventType(let eventType):
+                    return AnyView(Text("⚠️ Invalid event type \(String(describing: eventType))"))
+                }
+            } catch let error {
+                return AnyView(Text("⚠️ Unknown error \(String(describing: error))"))
+            }
         case .roomMember:
             return AnyView(
                 RoomMemberEventView(model: .init(event: event))

--- a/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
@@ -68,6 +68,12 @@ struct MessageViewModel: MessageViewModelProtocol {
     }
 
     private static func validate(event: MXEvent) throws {
+        // NOTE: For as long as https://github.com/matrix-org/matrix-ios-sdk/pull/843
+        // remains unresolved keep in mind that
+        // `.keyVerificationStart`, `.keyVerificationAccept`, `.keyVerificationKey`,
+        // `.keyVerificationMac`, `.keyVerificationCancel` & `.reaction`
+        // may get wrongly recognized as `.custom(…)`, instead.
+        // FIXME: Remove comment when linked bug fix has been merged.
         let eventType = MXEventType(identifier: event.type)
         guard eventType == .roomMessage else {
             throw Error.invalidEventType(eventType)

--- a/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageViewModel.swift
@@ -69,10 +69,7 @@ struct MessageViewModel: MessageViewModelProtocol {
 
     private static func validate(event: MXEvent) throws {
         let eventType = MXEventType(identifier: event.type)
-        // FIXME: Replace with simple `eventType == .roomMessage`
-        // once https://github.com/matrix-org/matrix-ios-sdk/pull/755 is part of a release (presumably v0.15.3):
-
-        guard case .roomMessage = eventType else {
+        guard eventType == .roomMessage else {
             throw Error.invalidEventType(eventType)
         }
     }

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -74,7 +74,7 @@ struct RoomView: View {
                                    reactions: self.events.reactions(for: event),
                                    connectedEdges: self.events.connectedEdges(of: event),
                                    showSender: !self.isDirect,
-                                   edits: self.events.relatedEvents(of: event),
+                                   edits: self.events.relatedEvents(of: event).filter { $0.isEdit() },
                                    contextMenuModel: EventContextMenuModel(
                                     event: event,
                                     userId: self.userId,


### PR DESCRIPTION
The force-unwrap should not crash the app, but rather show an error instead.