### PR TITLE
Add icon and background to typing indicator

### DIFF
--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -101,7 +101,7 @@ struct RoomView: View {
                     .padding(.horizontal)
             }
             if !(room.room.typingUsers?.filter { $0 != userId }.isEmpty ?? false) {
-                TypingIndicatorView()
+                TypingIndicatorContainerView()
             }
             MessageComposerView(
                 message: $message,

--- a/Nio/Conversations/TypingIndicatorView.swift
+++ b/Nio/Conversations/TypingIndicatorView.swift
@@ -1,28 +1,70 @@
 import SwiftUI
 
-struct TypingIndicatorView: View {
+struct TypingIndicatorContainerView: View {
     @EnvironmentObject private var room: NIORoom
     @Environment(\.userId) var userId
 
+    private var typingUsers: [String] {
+        room.room.typingUsers?.filter { $0 != userId} ?? []
+    }
+
+    var body: some View {
+        TypingIndicatorView(typingUsers: typingUsers)
+    }
+}
+
+struct TypingIndicatorView: View {
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    var typingUsers: [String]
+
     var text: String {
-        let users = (room.room.typingUsers?.filter { $0 != userId } ?? [])
-        switch users.count {
+        switch typingUsers.count {
         case 1:
-            return L10n.TypingIndicator.single(users.first!)
-        case 2...3:
-            return L10n.TypingIndicator.multiple(users.joined(separator: ", "))
+            return L10n.TypingIndicator.single(typingUsers.first!)
+        case 2:
+            return L10n.TypingIndicator.two(typingUsers[0], typingUsers[1])
         default:
             return L10n.TypingIndicator.many
         }
     }
 
+    var backgroundColor: Color {
+        switch self.colorScheme {
+        case .dark:
+            return Color(#colorLiteral(red: 0.1221848231, green: 0.1316168257, blue: 0.1457917546, alpha: 1))
+        default:
+            return Color(#colorLiteral(red: 0.968541801, green: 0.9726034999, blue: 0.9763545394, alpha: 1))
+        }
+    }
+
     var body: some View {
         HStack {
-            Text(text)
-                .font(.caption)
-                .foregroundColor(.gray)
+            Group {
+                Image(systemName: "ellipsis")
+                Text(text)
+            }
+            .font(.caption)
+            .foregroundColor(.gray)
             Spacer()
         }
-        .padding(.horizontal)
+        .padding(8)
+        .background(self.backgroundColor)
+    }
+}
+
+struct TypingIndicatorView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            TypingIndicatorView(typingUsers: ["Jane Doe"])
+            TypingIndicatorView(typingUsers: ["Jane Doe", "John Doe"])
+            TypingIndicatorView(typingUsers: ["Jane Doe", "John Doe", "Jill Doe"])
+
+            TypingIndicatorView(typingUsers: ["Jane Doe", "John Doe"])
+            .environment(\.colorScheme, .dark)
+
+            TypingIndicatorView(typingUsers: ["Jane Doe", "John Doe"])
+                .environment(\.sizeCategory, .accessibilityLarge)
+        }
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/Nio/Generated/Strings.swift
+++ b/Nio/Generated/Strings.swift
@@ -242,15 +242,15 @@ internal enum L10n {
   }
 
   internal enum TypingIndicator {
-    /// Several people are typing...
+    /// Several people are typing
     internal static let many = L10n.tr("Localizable", "typing-indicator.many")
-    /// %@ are typing...
-    internal static func multiple(_ p1: String) -> String {
-      return L10n.tr("Localizable", "typing-indicator.multiple", p1)
-    }
-    /// %@ is typing...
+    /// %@ is typing
     internal static func single(_ p1: String) -> String {
       return L10n.tr("Localizable", "typing-indicator.single", p1)
+    }
+    /// %@ and %@ are typing
+    internal static func two(_ p1: String, _ p2: String) -> String {
+      return L10n.tr("Localizable", "typing-indicator.two", p1, p2)
     }
   }
 }

--- a/Nio/Supporting Files/de.lproj/Localizable.strings
+++ b/Nio/Supporting Files/de.lproj/Localizable.strings
@@ -38,9 +38,9 @@
 "composer.accessibility-label.send" = "Senden";
 "composer.accessibility-label.cancelEdit" = "Abbrechen";
 
-"typing-indicator.single" = "%@ tippt...";
-"typing-indicator.multiple" = "%@ tippen...";
-"typing-indicator.many" = "Mehrere Leute tippen...";
+"typing-indicator.single" = "%@ tippt";
+"typing-indicator.multiple" = "%@ und %@ tippen";
+"typing-indicator.many" = "Mehrere Leute tippen";
 
 "event.unknown-sender-fallback" = "Unbekannt";
 "event.unknown-room-name-fallback" = "Unbekannt";

--- a/Nio/Supporting Files/en.lproj/Localizable.strings
+++ b/Nio/Supporting Files/en.lproj/Localizable.strings
@@ -38,9 +38,9 @@
 "composer.accessibility-label.send" = "Send";
 "composer.accessibility-label.cancelEdit" = "Cancel";
 
-"typing-indicator.single" = "%@ is typing...";
-"typing-indicator.multiple" = "%@ are typing...";
-"typing-indicator.many" = "Several people are typing...";
+"typing-indicator.single" = "%@ is typing";
+"typing-indicator.two" = "%@ and %@ are typing";
+"typing-indicator.many" = "Several people are typing";
 
 "event.unknown-sender-fallback" = "Unknown";
 "event.unknown-room-name-fallback" = "Unknown";

--- a/Nio/Supporting Files/es.lproj/Localizable.strings
+++ b/Nio/Supporting Files/es.lproj/Localizable.strings
@@ -33,9 +33,9 @@
 "composer.accessibility-label.send-file" = "Enviar archivo";
 "composer.accessibility-label.send" = "Enviar";
 "composer.accessibility-label.cancelEdit" = "Cancelar";
-"typing-indicator.single" = "%@ está escribiendo...";
-"typing-indicator.multiple" = "%@ están escribiendo...";
-"typing-indicator.many" = "Múltiples usuarios están escribiendo...";
+"typing-indicator.single" = "%@ está escribiendo";
+"typing-indicator.multiple" = "%@ y %@ están escribiendo";
+"typing-indicator.many" = "Múltiples personas están escribiendo";
 "event.unknown-sender-fallback" = "Desconocido";
 "event.unknown-room-name-fallback" = "Desconocido";
 "event.room-member.invited" = "%@ invitó a %@";

--- a/Nio/Supporting Files/nl.lproj/Localizable.strings
+++ b/Nio/Supporting Files/nl.lproj/Localizable.strings
@@ -38,9 +38,9 @@
 "composer.accessibility-label.send" = "Verstuur";
 "composer.accessibility-label.cancelEdit" = "Annuleer";
 
-"typing-indicator.single" = "%@ is aan het typen...";
-"typing-indicator.multiple" = "%@ zijn aan het typen...";
-"typing-indicator.many" = "Meerdere personen zijn aan het typen...";
+"typing-indicator.single" = "%@ is aan het typen";
+"typing-indicator.multiple" = "%@ en %@ zijn aan het typen";
+"typing-indicator.many" = "Meerdere personen zijn aan het typen";
 
 "event.unknown-sender-fallback" = "Onbekend";
 "event.unknown-room-name-fallback" = "Onbekend";

--- a/Nio/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Nio/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -33,9 +33,9 @@
 "composer.accessibility-label.send-file" = "发送文件";
 "composer.accessibility-label.send" = "发送";
 "composer.accessibility-label.cancelEdit" = "取消";
-"typing-indicator.single" = "%@正在输入...";
-"typing-indicator.multiple" = "%@正在输入...";
-"typing-indicator.many" = "多位正在输入...";
+"typing-indicator.single" = "%@正在输入";
+"typing-indicator.multiple" = "%@和%@正在输入";
+"typing-indicator.many" = "多位正在输入";
 "event.unknown-sender-fallback" = "未知发送者";
 "event.unknown-room-name-fallback" = "未知房间名";
 "event.room-member.invited" = "%@邀请了%@";


### PR DESCRIPTION
This adds an icon (SF Symbol ellipsis) at the front and a background color to the typing indicator, so it doesn't look so completely out of place.

It also now shows "several people" for anything above 2, not 3 like previously. It was hard to read, crowded and huge with accessibility text sizes before.
The change also updates the translations to use two placeholders and a localized form of "and", since comma separated usernames might not localize well across languages.

<img width="555" alt="Screen Shot 2020-05-10 at 14 32 07" src="https://user-images.githubusercontent.com/2625584/81499323-12d22600-92cb-11ea-9b32-6eedcaaf264a.png">


<img width="482" alt="Screen Shot 2020-05-10 at 14 27 39" src="https://user-images.githubusercontent.com/2625584/81499268-b1aa5280-92ca-11ea-8f94-6156523a2f93.png">
