### PR TITLE
Pass text color to MarkdownText

### DIFF
--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -28,14 +28,6 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         }
     }
 
-    var textColor: Color {
-        if isMe {
-            return .lightText(for: colorScheme, with: colorSchemeContrast)
-        } else {
-            return .primaryText(for: colorScheme, with: colorSchemeContrast)
-        }
-    }
-
     var backgroundColor: Color {
         if isMe {
             return .accentColor
@@ -84,6 +76,7 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
     var markdownView: some View {
         MarkdownText(
             markdown: .constant(model.text),
+            textColor: .messageTextColor(for: colorScheme, isOutgoing: isMe),
             linkTextAttributes: [
                 .foregroundColor: linkColor,
                 .underlineStyle: NSUnderlineStyle.single.rawValue,

--- a/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
@@ -11,13 +11,6 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
     var connectedEdges: ConnectedEdges
     var isEdited = false
 
-    var textColor: Color {
-        if model.sender == userId {
-            return .lightText(for: colorScheme, with: colorSchemeContrast)
-        }
-        return .primaryText(for: colorScheme, with: colorSchemeContrast)
-    }
-
     var isMe: Bool {
         model.sender == userId
     }

--- a/Nio/Conversations/Event Views/MessageView/Reactions/ReactionsListItemView.swift
+++ b/Nio/Conversations/Event Views/MessageView/Reactions/ReactionsListItemView.swift
@@ -18,12 +18,9 @@ struct ReactionsListItemView: View {
     var body: some View {
         HStack {
             Text(self.reaction.reaction)
-                .foregroundColor(Color.primaryText(for: colorScheme, with: colorSchemeContrast))
             Text(self.reaction.sender)
-                .foregroundColor(Color.primaryText(for: colorScheme, with: colorSchemeContrast))
             Spacer()
             Text(timestamp)
-                .foregroundColor(Color.primaryText(for: colorScheme, with: colorSchemeContrast))
                 .font(.footnote)
         }
     }

--- a/Nio/Conversations/MessageComposerView.swift
+++ b/Nio/Conversations/MessageComposerView.swift
@@ -44,10 +44,6 @@ struct MessageComposerView: View {
     var onCancel: () -> Void
     var onCommit: () -> Void
 
-    var textColor: Color {
-        .primaryText(for: colorScheme, with: colorSchemeContrast)
-    }
-
     var backgroundColor: Color {
         colorScheme == .light ? Color(#colorLiteral(red: 0.9332506061, green: 0.937307477, blue: 0.9410644174, alpha: 1)) : Color(#colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1))
     }

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -63,7 +63,7 @@ struct RoomListItemView: View {
             .allowsTightening(true)
             .padding(10 * sizeCategory.scalingFactor)
             .aspectRatio(1.0, contentMode: .fill)
-            .foregroundColor(.lightText(for: colorScheme, with: colorSchemeContrast))
+            .foregroundColor(.init(UIColor.textOnAccentColor(for: colorScheme)))
             .background(
                 Circle()
                     .foregroundColor(.accentColor)
@@ -120,7 +120,7 @@ struct RoomListItemView: View {
             .font(.caption)
             .lineLimit(1)
             .allowsTightening(true)
-            .foregroundColor(.lightText(for: colorScheme, with: colorSchemeContrast))
+            .foregroundColor(.init(UIColor.textOnAccentColor(for: colorScheme)))
             // Make sure we get enough "breathing air" around the number:
             .padding(.vertical, 3 * sizeCategory.scalingFactor)
             .padding(.horizontal, 6 * sizeCategory.scalingFactor)

--- a/Nio/Extensions/Color+Named.swift
+++ b/Nio/Extensions/Color+Named.swift
@@ -13,6 +13,7 @@ extension Color {
 }
 
 extension UIColor {
+    /// Color of text that is shown on top of the accent color, e.g. badges.
     static func textOnAccentColor(for colorScheme: ColorScheme) -> UIColor {
         messageTextColor(for: colorScheme, isOutgoing: true)
     }

--- a/Nio/Extensions/Color+Named.swift
+++ b/Nio/Extensions/Color+Named.swift
@@ -10,27 +10,23 @@ extension Color {
             return .white
         }
     }
+}
 
-    static func lightText(for colorScheme: ColorScheme,
-                          with colorSchemeContrast: ColorSchemeContrast) -> Color {
-        if colorSchemeContrast == .standard {
+extension UIColor {
+    static func textOnAccentColor(for colorScheme: ColorScheme) -> UIColor {
+        messageTextColor(for: colorScheme, isOutgoing: true)
+    }
+
+    static func messageTextColor(for colorScheme: ColorScheme,
+                                 isOutgoing: Bool) -> UIColor {
+        if isOutgoing {
             return .white
         }
         switch colorScheme {
-        case .light:
-            return .white
         case .dark:
-            return .black
-        @unknown default:
             return .white
+        default:
+            return .black
         }
-    }
-
-    static func primaryText(for colorScheme: ColorScheme,
-                            with colorSchemeContrast: ColorSchemeContrast) -> Color {
-        if colorSchemeContrast == .standard {
-            return .primary
-        }
-        return .black
     }
 }

--- a/Nio/Shared Views/MarkdownText.swift
+++ b/Nio/Shared Views/MarkdownText.swift
@@ -4,6 +4,7 @@ import CommonMarkAttributedString
 
 struct MarkdownText: View {
     @Binding var markdown: String
+    var textColor: UIColor
 
     @State private var calculatedHeight: CGFloat = 0.0
 
@@ -13,18 +14,20 @@ struct MarkdownText: View {
 
     public init(
         markdown: Binding<String>,
+        textColor: UIColor,
         linkTextAttributes: [NSAttributedString.Key: Any]? = nil,
         onLinkInteraction: (((URL, UITextItemInteraction) -> Bool))? = nil
     ) {
         self._markdown = markdown
+        self.textColor = textColor.resolvedColor(with: .current)
         self.linkTextAttributes = linkTextAttributes
         self.onLinkInteraction = onLinkInteraction
     }
 
-    internal static var attributes: [NSAttributedString.Key: Any] {
+    internal var attributes: [NSAttributedString.Key: Any] {
         [
             NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .body),
-            NSAttributedString.Key.foregroundColor: UIColor.label,
+            NSAttributedString.Key.foregroundColor: self.textColor,
         ]
     }
 
@@ -32,7 +35,7 @@ struct MarkdownText: View {
         Binding<NSAttributedString>(
             get: {
                 let markdownString = self.markdown.trimmingCharacters(in: .whitespacesAndNewlines)
-                let attributes = Self.attributes
+                let attributes = self.attributes
                 let attributedString = try? NSAttributedString(
                     commonmark: markdownString,
                     attributes: attributes
@@ -87,6 +90,7 @@ struct MarkdownText_Previews: PreviewProvider {
         """#
         return MarkdownText(
             markdown: .constant(markdownString),
+            textColor: .messageTextColor(for: .light, isOutgoing: false),
             linkTextAttributes: [
                 .foregroundColor: UIColor.blue,
                 .underlineStyle: NSUnderlineStyle.single.rawValue,


### PR DESCRIPTION
This also removes the lightText and primaryText extensions on Color and replaces them with messageTextColor and textOnAccentColor that carry a bit more semantic meaning.

This resolves #117, but does in its current form undo the first changes that were made for #65.