### PR TITLE
Changed the contents of '.swiftlint.yml' file 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,10 +1,22 @@
-excluded:
-  - Pods
-
-identifier_name:
-  excluded:
-    - id
-    - ts
-
 disabled_rules:
   - trailing_comma
+  - empty_enum_arguments
+  - void_return
+  - redundant_optional_initialization
+  - nesting
+  - redundant_discardable_let
+  - opening_brace
+excluded:
+  - Pods
+line_length:
+  warning: 140
+  error: 140
+identifier_name:
+  excluded:
+    - 'id'
+    - 'i'
+    - 'x'
+    - 'y'
+    - 'z'
+type_name:
+  max_length: 60


### PR DESCRIPTION
… from "wrong on so many levels" to "something useful".

- `trailing_comma`:
  Why on earth would you want to forbid trailing commas? Why? 🤯

- `empty_enum_arguments`:
  What if I _want_ to make visible that there _is_ an associated value, I'm just not _using_ it?

- `void_return`:
  `() -> Void` looks like you're dealing with two different types. It's one. It's actually called `()`
  Let's face it: `Void` (an alias) just exists to lure in the objc nostalgics. 🙄

- `redundant_optional_initialization`:
  This one actually boggles my mind. 🤯 There is a semantic difference between explicit `…? = nil` and the implicit variant: the former propagates the default argument to the generated initializer, while the latter doesn't. Also for the love of consistency, let me define a value for optionals.

- `nesting`:
  "Types should be nested at most 1 level deep". What 👏 The 👏 Heck? 🤬

- `redundant_discardable_let`:
  If it's an l-value declaration grammatically, it should have a `let`. Don't at me.

- `opening_brace`:
  No, just no.

It's amazing how swiftlint's defaults manage to make one's code actually _less_ consistent. 🤦🏻‍♂️