### PR TITLE
Added pending invitations to the recent rooms view

### DIFF
--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -70,14 +70,14 @@ struct RecentRoomsView: View {
                         sectionHeader: "Pending Invitations",
                         rooms: invitedRooms,
                         onLeaveAlertTitle: "Reject Invitation?"
-                        )
+                    )
                 }
 
                 RoomsListSection(
-                    sectionHeader: "Recent Conversations",
+                    sectionHeader: nil,
                     rooms: joinedRooms,
                     onLeaveAlertTitle: L10n.RecentRooms.Leave.alertTitle
-                    )
+                )
 
             }
             .navigationBarTitle("Nio", displayMode: .inline)
@@ -88,10 +88,10 @@ struct RecentRoomsView: View {
 }
 
 struct RoomsListSection: View {
+    let sectionHeader: String?
+    let rooms: [NIORoom]
+    let onLeaveAlertTitle: String
 
-    var sectionHeader: String
-    var rooms: [NIORoom]
-    var onLeaveAlertTitle: String
     @State private var showConfirm: Bool = false
     @State private var leaveId: Int?
 
@@ -103,16 +103,30 @@ struct RoomsListSection: View {
         return self.rooms[leaveId]
     }
 
-    var body: some View {
-        Section(header: Text(sectionHeader)) {
-            ForEach(rooms) { room in
-                NavigationLink(destination: RoomContainerView(room: room)) {
-                    RoomListItemContainerView(room: room)
-                }
+    var sectionContent: some View {
+        ForEach(rooms) { room in
+            NavigationLink(destination: RoomContainerView(room: room)) {
+                RoomListItemContainerView(room: room)
             }
-
-            .onDelete(perform: setLeaveIndex)
         }
+        .onDelete(perform: setLeaveIndex)
+    }
+
+    @ViewBuilder
+    var section: some View {
+        if let sectionHeader = sectionHeader {
+            Section(header: Text(sectionHeader)) {
+                sectionContent
+            }
+        } else {
+            Section {
+                sectionContent
+            }
+        }
+    }
+
+    var body: some View {
+        section
         .alert(isPresented: $showConfirm) {
             Alert(
                 title: Text(onLeaveAlertTitle),

--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -67,9 +67,9 @@ struct RecentRoomsView: View {
             List {
                 if !invitedRooms.isEmpty {
                     RoomsListSection(
-                        sectionHeader: "Pending Invitations",
+                        sectionHeader: L10n.RecentRooms.PendingInvitations.header,
                         rooms: invitedRooms,
-                        onLeaveAlertTitle: "Reject Invitation?"
+                        onLeaveAlertTitle: L10n.RecentRooms.PendingInvitations.Leave.alertTitle
                     )
                 }
 

--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -32,12 +32,12 @@ struct RecentRoomsView: View {
 
     var rooms: [NIORoom]
 
-    var joined_rooms: [NIORoom] {
-        return self.rooms.filter({$0.room.summary.membership == .join})
+    var joinedRooms: [NIORoom] {
+        rooms.filter {$0.room.summary.membership == .join}
     }
 
-    var invited_rooms: [NIORoom] {
-        return self.rooms.filter({$0.room.summary.membership == .invite})
+    var invitedRooms: [NIORoom] {
+        rooms.filter {$0.room.summary.membership == .invite}
     }
 
     var settingsButton: some View {
@@ -65,11 +65,11 @@ struct RecentRoomsView: View {
     var body: some View {
         NavigationView {
             List {
-                if self.invited_rooms.count > 0 {
-                    RoomsListSection(sectionHeader: "Pending Invitations", rooms: invited_rooms, alertTitle: "Reject Invitation?")
+                if !invitedRooms.isEmpty {
+                    RoomsListSection(sectionHeader: "Pending Invitations", rooms: invitedRooms, onLeaveAlertTitle: "Reject Invitation?")
                 }
     
-                RoomsListSection(sectionHeader: "Recent Conversations", rooms: joined_rooms, alertTitle: "Leave Room?")
+                RoomsListSection(sectionHeader: "Recent Conversations", rooms: joinedRooms, onLeaveAlertTitle: L10n.RecentRooms.Leave.alertTitle)
 
             }
             .navigationBarTitle("Nio", displayMode: .inline)
@@ -83,7 +83,7 @@ struct RoomsListSection: View {
 
     var sectionHeader: String
     var rooms: [NIORoom]
-    var alertTitle: String
+    var onLeaveAlertTitle: String
     @State private var showConfirm: Bool = false
     @State private var leaveId: Int?
 
@@ -108,7 +108,7 @@ struct RoomsListSection: View {
         .alert(isPresented: $showConfirm) {
             Alert(
                 //title: Text(L10n.RecentRooms.Leave.alertTitle),
-                title: Text(alertTitle),
+                title: Text(onLeaveAlertTitle),
                 message: Text(L10n.RecentRooms.Leave.alertBody(
                     roomToLeave?.summary.displayname
                         ?? roomToLeave?.summary.roomId

--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -68,7 +68,7 @@ struct RecentRoomsView: View {
                 if !invitedRooms.isEmpty {
                     RoomsListSection(sectionHeader: "Pending Invitations", rooms: invitedRooms, onLeaveAlertTitle: "Reject Invitation?")
                 }
-    
+
                 RoomsListSection(sectionHeader: "Recent Conversations", rooms: joinedRooms, onLeaveAlertTitle: L10n.RecentRooms.Leave.alertTitle)
 
             }

--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -66,10 +66,18 @@ struct RecentRoomsView: View {
         NavigationView {
             List {
                 if !invitedRooms.isEmpty {
-                    RoomsListSection(sectionHeader: "Pending Invitations", rooms: invitedRooms, onLeaveAlertTitle: "Reject Invitation?")
+                    RoomsListSection(
+                        sectionHeader: "Pending Invitations",
+                        rooms: invitedRooms,
+                        onLeaveAlertTitle: "Reject Invitation?"
+                        )
                 }
 
-                RoomsListSection(sectionHeader: "Recent Conversations", rooms: joinedRooms, onLeaveAlertTitle: L10n.RecentRooms.Leave.alertTitle)
+                RoomsListSection(
+                    sectionHeader: "Recent Conversations",
+                    rooms: joinedRooms,
+                    onLeaveAlertTitle: L10n.RecentRooms.Leave.alertTitle
+                    )
 
             }
             .navigationBarTitle("Nio", displayMode: .inline)

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -57,13 +57,11 @@ struct RoomContainerView: View {
                 secondaryButton: .cancel())
         }
         .onAppear {
-            switch(self.room.summary.membership) {
+            switch self.room.summary.membership {
             case .invite:
                 self.showJoinAlert = true
-                break
             case .join:
                 self.room.markAllAsRead()
-                break
             default:
                 break
             }

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -43,12 +43,12 @@ struct RoomContainerView: View {
             }
         }
         .alert(isPresented: $showJoinAlert) {
-            let roomName = self.room.summary.displayname ?? self.room.summary.roomId ?? "New Conversation"
+            let roomName = self.room.summary.displayname ?? self.room.summary.roomId ?? L10n.Room.Invitation.fallbackTitle
             return Alert(
-                title: Text("Join Conversation?"),
-                message: Text("Accept invitation to join '\(roomName)'?"),
+                title: Text(L10n.Room.Invitation.JoinAlert.title),
+                message: Text(L10n.Room.Invitation.JoinAlert.message(roomName)),
                 primaryButton: .default(
-                    Text("Join"),
+                    Text(L10n.Room.Invitation.JoinAlert.joinButton),
                     action: {
                         self.room.room.mxSession.joinRoom(self.room.room.roomId) { _ in
                             self.room.markAllAsRead()

--- a/Nio/Generated/Strings.swift
+++ b/Nio/Generated/Strings.swift
@@ -199,6 +199,14 @@ internal enum L10n {
       /// Leave Room
       internal static let alertTitle = L10n.tr("Localizable", "recent-rooms.leave.alert-title")
     }
+    internal enum PendingInvitations {
+      /// Pending Invitations
+      internal static let header = L10n.tr("Localizable", "recent-rooms.pending-invitations.header")
+      internal enum Leave {
+        /// Reject Invitation?
+        internal static let alertTitle = L10n.tr("Localizable", "recent-rooms.pending-invitations.leave.alert-title")
+      }
+    }
   }
 
   internal enum Room {
@@ -207,6 +215,20 @@ internal enum L10n {
       internal static let selectType = L10n.tr("Localizable", "room.attachment.select-type")
       /// Photo
       internal static let typePhoto = L10n.tr("Localizable", "room.attachment.type-photo")
+    }
+    internal enum Invitation {
+      /// New Conversation
+      internal static let fallbackTitle = L10n.tr("Localizable", "room.invitation.fallback-title")
+      internal enum JoinAlert {
+        /// Join
+        internal static let joinButton = L10n.tr("Localizable", "room.invitation.join-alert.join-button")
+        /// Accept invitation to join '%@'?
+        internal static func message(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "room.invitation.join-alert.message", String(describing: p1))
+        }
+        /// Join Conversation?
+        internal static let title = L10n.tr("Localizable", "room.invitation.join-alert.title")
+      }
     }
     internal enum Remove {
       /// Remove

--- a/Nio/Supporting Files/de.lproj/Localizable.strings
+++ b/Nio/Supporting Files/de.lproj/Localizable.strings
@@ -21,6 +21,8 @@
 // Room $NAME, $LAST_ACTIVITY_TIMESTAMP $LAST_MESSAGE
 "recent-rooms.accessibility-label.room" = "Raum %@, %@ %@";
 "recent-rooms.accessibility-label.new-message-badge" = "%u neue Nachrichten";
+"recent-rooms.pending-invitations.header" = "Offene Einladungen";
+"recent-rooms.pending-invitations.leave.alert-title" = "Einladung ablehnen?";
 "recent-rooms.leave.alert-title" = "Raum verlassen";
 "recent-rooms.leave.alert-body" = "Bist du sicher, dass du '%@' verlassen möchtest? Dies kann nicht rückgängig gemacht werden.";
 "room.attachment.select-type" = "Anhang senden";
@@ -28,6 +30,10 @@
 "room.remove.title" = "Entfernen?";
 "room.remove.message" = "Bist du sicher, dass du diese Nachricht entfernen möchtest?";
 "room.remove.action" = "Entfernen";
+"room.invitation.fallback-title" = "Neue Unterhaltung";
+"room.invitation.join-alert.title" = "Unterhaltung beitreten?";
+"room.invitation.join-alert.message" = "Raum '%@' beitreten?";
+"room.invitation.join-alert.join-button" = "Beitreten";
 "composer.new-message" = "Neue Nachricht...";
 "composer.edit-message" = "Nachricht bearbeiten:";
 "composer.accessibility-label.send-file" = "Anhang senden";

--- a/Nio/Supporting Files/en.lproj/Localizable.strings
+++ b/Nio/Supporting Files/en.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 // Room $NAME, $LAST_ACTIVITY_TIMESTAMP $LAST_MESSAGE
 "recent-rooms.accessibility-label.room" = "Room %@, %@ %@";
 "recent-rooms.accessibility-label.new-message-badge" = "%u new messages";
+"recent-rooms.pending-invitations.header" = "Pending Invitations";
+"recent-rooms.pending-invitations.leave.alert-title" = "Reject Invitation?";
 "recent-rooms.leave.alert-title" = "Leave Room";
 "recent-rooms.leave.alert-body" = "Are you sure you want to leave '%@'? This action cannot be undone.";
 
@@ -31,6 +33,10 @@
 "room.remove.title" = "Remove?";
 "room.remove.message" = "Are you sure you want to remove this message?";
 "room.remove.action" = "Remove";
+"room.invitation.fallback-title" = "New Conversation";
+"room.invitation.join-alert.title" = "Join Conversation?";
+"room.invitation.join-alert.message" = "Accept invitation to join '%@'?";
+"room.invitation.join-alert.join-button" = "Join";
 
 "composer.new-message" = "New Message...";
 "composer.edit-message" = "Edit Message:";

--- a/Nio/Supporting Files/es.lproj/Localizable.strings
+++ b/Nio/Supporting Files/es.lproj/Localizable.strings
@@ -21,6 +21,8 @@
 /*Room $NAME, $LAST_ACTIVITY_TIMESTAMP $LAST_MESSAGE*/
 "recent-rooms.accessibility-label.room" = "Sala %@, %@ %@";
 "recent-rooms.accessibility-label.new-message-badge" = "%u nuevos mensajes";
+"recent-rooms.pending-invitations.header" = "Invitaciones pendientes";
+"recent-rooms.pending-invitations.leave.alert-title" = "¿Rechazar la invitación?";
 "recent-rooms.leave.alert-title" = "Deje la habitación";
 "recent-rooms.leave.alert-body" = "¿Estás seguro de que quieres dejar '%@'? Esta acción no puede deshacerse.";
 "room.attachment.select-type" = "Envíe el archivo adjunto";
@@ -28,6 +30,10 @@
 "room.remove.title" = "¿Eliminar?";
 "room.remove.message" = "¿Está seguro de que desea eliminar este mensaje?";
 "room.remove.action" = "Eliminar";
+"room.invitation.fallback-title" = "Nueva conversación";
+"room.invitation.join-alert.title" = "¿Unirse a la conversación?";
+"room.invitation.join-alert.message" = "¿Aceptas la invitación para unirte a '%@'?";
+"room.invitation.join-alert.join-button" = "Únete a";
 "composer.new-message" = "Nuevo mensaje...";
 "composer.edit-message" = "Editar Mensaje:";
 "composer.accessibility-label.send-file" = "Enviar archivo";

--- a/Nio/Supporting Files/nl.lproj/Localizable.strings
+++ b/Nio/Supporting Files/nl.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 // Room $NAME, $LAST_ACTIVITY_TIMESTAMP $LAST_MESSAGE
 "recent-rooms.accessibility-label.room" = "Kamer %@, %@ %@";
 "recent-rooms.accessibility-label.new-message-badge" = "%u nieuwe berichten";
+"recent-rooms.pending-invitations.header" = "In afwachting van uitnodigingen";
+"recent-rooms.pending-invitations.leave.alert-title" = "Uitnodiging afwijzen?";
 "recent-rooms.leave.alert-title" = "Gesprek Verwijderen";
 "recent-rooms.leave.alert-body" = "Weet u zeker dat je '%@' wilt verlaten? Deze actie can niet ongedaan gemaakt worden.";
 
@@ -31,6 +33,10 @@
 "room.remove.title" = "Verwijderen?";
 "room.remove.message" = "Weet u zeker dat u dit bericht wilt verwijderen?";
 "room.remove.action" = "Verwijderen";
+"room.invitation.fallback-title" = "Nieuw gesprek";
+"room.invitation.join-alert.title" = "Doe je mee met het gesprek?";
+"room.invitation.join-alert.message" = "Accepteer je de uitnodiging om deel te nemen aan '%@'?";
+"room.invitation.join-alert.join-button" = "Toetreden";
 
 "composer.new-message" = "Nieuw Bericht...";
 "composer.edit-message" = "Bewerk Bericht:";

--- a/Nio/Supporting Files/ru.lproj/Localizable.strings
+++ b/Nio/Supporting Files/ru.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 // Room $NAME, $LAST_ACTIVITY_TIMESTAMP $LAST_MESSAGE
 "recent-rooms.accessibility-label.room" = "Группа %@, %@ %@";
 "recent-rooms.accessibility-label.new-message-badge" = "%u новых сообщений";
+"recent-rooms.pending-invitations.header" = "Ожидающие приглашения";
+"recent-rooms.pending-invitations.leave.alert-title" = "Отклонить приглашение?";
 "recent-rooms.leave.alert-title" = "Покинуть Группу";
 "recent-rooms.leave.alert-body" = "Вы уверены, что хотите покинуть '%@'? Это действие нельзя отменить.";
 "room.attachment.select-type" = "Отправить вложение";
@@ -26,6 +28,10 @@
 "room.remove.title" = "Удалить?";
 "room.remove.message" = "Вы уверены, что ходите удалить это сообщение?";
 "room.remove.action" = "Удалить";
+"room.invitation.fallback-title" = "Новое Обращение";
+"room.invitation.join-alert.title" = "Присоединиться к разговору?";
+"room.invitation.join-alert.message" = "Принять приглашение присоединиться к \"%@\"?";
+"room.invitation.join-alert.join-button" = "Присоединяйся";
 "composer.new-message" = "Новое сообщение...";
 "composer.edit-message" = "Редактировать сообщение:";
 "composer.accessibility-label.send-file" = "Отправить файл";

--- a/Nio/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Nio/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -21,6 +21,8 @@
 /*Room $NAME, $LAST_ACTIVITY_TIMESTAMP $LAST_MESSAGE*/
 "recent-rooms.accessibility-label.room" = "房间%@, %@ %@";
 "recent-rooms.accessibility-label.new-message-badge" = "%u条新信息";
+"recent-rooms.pending-invitations.header" = "待定邀请函";
+"recent-rooms.pending-invitations.leave.alert-title" = "拒绝邀请？";
 "recent-rooms.leave.alert-title" = "留有余地";
 "recent-rooms.leave.alert-body" = "你确定要留下\"%@\"吗？这个动作是无法撤销的。";
 "room.attachment.select-type" = "发送附件";
@@ -28,6 +30,10 @@
 "room.remove.title" = "删除？";
 "room.remove.message" = "你确定要删除这条消息吗？";
 "room.remove.action" = "删除";
+"room.invitation.fallback-title" = "新对话";
+"room.invitation.join-alert.title" = "加入对话？";
+"room.invitation.join-alert.message" = "接受邀请加入'%@'？";
+"room.invitation.join-alert.join-button" = "加入";
 "composer.new-message" = "新信息...";
 "composer.edit-message" = "编辑信息：";
 "composer.accessibility-label.send-file" = "发送文件";

--- a/NioKit/Models/NIORoom.swift
+++ b/NioKit/Models/NIORoom.swift
@@ -16,6 +16,14 @@ public class NIORoom: ObservableObject {
     }
 
     public var lastMessage: String {
+        if summary.membership == .invite {
+            let inviteEvent = eventCache.last {
+                $0.type == kMXEventTypeStringRoomMember && $0.stateKey == room.mxSession.myUserId
+            }
+            guard let sender = inviteEvent?.sender else { return "" }
+            return "Invitation from: \(sender)"
+        }
+
         let lastMessageEvent = eventCache.last {
             $0.type == kMXEventTypeStringRoomMessage
         }


### PR DESCRIPTION
My first attempt at showing pending invites in the recent rooms view, as a first step toward accepting new room invites #156 .

This PR moves a lot of the RecentRoomsList code out into a new View that makes a SwiftUI Section with header and content.  Then we have one section for invitations (if any) and one section for joined rooms.

Still no support for joining the new rooms though.  I wanted to get feedback on this part first.