### PR TITLE
Fix message wrapping on iOS 14

### DIFF
--- a/Nio/Shared Views/UITextViewWrapper.swift
+++ b/Nio/Shared Views/UITextViewWrapper.swift
@@ -10,7 +10,7 @@ struct UITextViewWrapper: UIViewRepresentable {
     @Binding var isEditing: Bool
     @Binding var sizeThatFits: CGSize
 
-    @State private var maxSize: CGSize
+    private let maxSize: CGSize
 
     private let textAttributes: TextAttributes
 
@@ -32,7 +32,7 @@ struct UITextViewWrapper: UIViewRepresentable {
         self._isEditing = isEditing
         self._sizeThatFits = sizeThatFits
 
-        self._maxSize = State(initialValue: maxSize)
+        self.maxSize = maxSize
 
         self.textAttributes = textAttributes
 


### PR DESCRIPTION
It seems to fix the broken message text wrapping in iOS 14 for some weird reason.

I was about to look into the issue and just wondered if the the `@State var` was actually necessary. So I took it out and relaunched the app in the simulator.

@kiliankoe would be nice if you could verify that this also fixes the issue for you.

(Fixes https://github.com/niochat/nio/issues/163)