### PR TITLE
Fixes non-square avatar images being stretched.

### DIFF
--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -143,6 +143,7 @@ struct RoomListItemView: View {
                 WebImage(url: avatarURL)
                     .resizable()
                     .placeholder { prefixAvatar }
+                    .aspectRatio(contentMode: .fill)
             )
         } else {
             return AnyView(
@@ -155,9 +156,10 @@ struct RoomListItemView: View {
 
     var body: some View {
         HStack(alignment: .center) {
-            image
+            Circle()
+                .foregroundColor(.clear)
                 .aspectRatio(1, contentMode: .fill)
-                .mask(Circle())
+                .overlay(image.mask(Circle()))
 
             VStack(alignment: .leading, spacing: 0) {
                 topView

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -136,6 +136,13 @@ struct RoomListItemView: View {
                 }
             )
     }
+    
+    var avatarView: some View {
+        Circle()
+            .foregroundColor(.clear)
+            .aspectRatio(1, contentMode: .fill)
+            .overlay(image.mask(Circle()))
+    }
 
     var image: some View {
         if let avatarURL = roomAvatarURL {
@@ -156,11 +163,7 @@ struct RoomListItemView: View {
 
     var body: some View {
         HStack(alignment: .center) {
-            Circle()
-                .foregroundColor(.clear)
-                .aspectRatio(1, contentMode: .fill)
-                .overlay(image.mask(Circle()))
-
+            avatarView
             VStack(alignment: .leading, spacing: 0) {
                 topView
                 bottomView


### PR DESCRIPTION
Non-square avatars were being stretched to fit within the circle mask. This fixes that.

Let me know if you'd prefer the changes to all be within `image` so that `body` looks cleaner and I'll update 🙂