### PR TITLE
Fix debug build provisioning error in NioShareExtension.

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -1586,6 +1586,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NioShareExtension/NioShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = NioShareExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
When using LocalConfig.xcconfig there was a provisioning error with a missing entitlement. Allow Xcode to resolve that.