### PR TITLE
Add Link to elements.io to create a new account

### DIFF
--- a/Nio/Authentication/LoginView.swift
+++ b/Nio/Authentication/LoginView.swift
@@ -88,7 +88,7 @@ struct LoginView: View {
             Spacer()
         }
         .sheet(isPresented: $showingRegisterView) {
-            Text(L10n.Login.registerNotYetImplemented)
+            Link(L10n.Login.registerNotYetImplemented, destination: URL(string: "https://app.element.io/#/register")!)
         }
     }
 


### PR DESCRIPTION
As long as #98 is not implemented, please add a link to a matrix instance, which allows easy registration without searching the web. Unfortunately you have to remember the credentials (or use the keychain), to switch back and to login with the just created credentials.
I integrated the link via a `Link` on the existing text. 
Maybe a VStack with a second Button("Click here to register") would be better?