### PR TITLE
Add Loading View Cancel Button Padding

### DIFF
--- a/Nio/Authentication/LoadingView.swift
+++ b/Nio/Authentication/LoadingView.swift
@@ -39,7 +39,7 @@ struct LoadingView: View {
                 self.store.logout()
             }, label: {
                 Text(L10n.Loading.cancel).font(.callout)
-            })
+            }).padding()
         }
     }
 }


### PR DESCRIPTION
Add padding to the button so that it would look nicer on devices without home indicators (i.e. still using home buttons).