### PR TITLE
Fix missing messages (1 part of #50)

### DIFF
--- a/NioKit/Models/NIORoom.swift
+++ b/NioKit/Models/NIORoom.swift
@@ -61,33 +61,6 @@ public class NIORoom: ObservableObject {
         print("Got \(currentBatch.count) events.")
 
         self.eventCache.append(contentsOf: currentBatch)
-
-        self.registerInUserDefaults(room: room)
-    }
-
-    private func registerInUserDefaults(room: MXRoom) {
-        let defaults = UserDefaults.group
-        let roomItem: RoomItem = RoomItem(room: room)
-        var rooms: [RoomItem]
-        let data = defaults.data(forKey: "roomList")
-        do {
-            if data != nil {
-                let decoder = JSONDecoder()
-                rooms = try decoder.decode([RoomItem].self, from: data!)
-            } else {
-                rooms = []
-            }
-            rooms.append(roomItem)
-            do {
-                let encoder = JSONEncoder()
-                let data = try encoder.encode(rooms)
-                defaults.set(data, forKey: "roomList")
-            } catch {
-                print("An error occured: \(error)")
-            }
-        } catch {
-            print("An error occured: \(error)")
-        }
     }
 
     public func add(event: MXEvent, direction: MXTimelineDirection, roomState: MXRoomState?) {

--- a/NioKit/Session/AccountStore.swift
+++ b/NioKit/Session/AccountStore.swift
@@ -149,9 +149,9 @@ public class AccountStore: ObservableObject {
         }
     }
 
-    internal var roomCache = [ObjectIdentifier: NIORoom]()
+    private var roomCache = [ObjectIdentifier: NIORoom]()
 
-    internal func makeRoom(from mxRoom: MXRoom) -> NIORoom {
+    private func makeRoom(from mxRoom: MXRoom) -> NIORoom {
         let room = NIORoom(mxRoom)
         roomCache[mxRoom.id] = room
         return room

--- a/NioKit/Session/AccountStore.swift
+++ b/NioKit/Session/AccountStore.swift
@@ -149,11 +149,19 @@ public class AccountStore: ObservableObject {
         }
     }
 
+    internal var roomCache = [ObjectIdentifier: NIORoom]()
+
+    internal func makeRoom(from mxRoom: MXRoom) -> NIORoom {
+        let room = NIORoom(mxRoom)
+        roomCache[mxRoom.id] = room
+        return room
+    }
+
     public var rooms: [NIORoom] {
+        guard let session = self.session else { return [] }
         UserDefaults.group.removeObject(forKey: "roomList")
-        return self.session?.rooms
-            .map { NIORoom($0) }
+        return session.rooms
+            .map { roomCache[$0.id] ?? makeRoom(from: $0) }
             .sorted { $0.summary.lastMessageDate > $1.summary.lastMessageDate }
-            ?? []
     }
 }

--- a/NioKit/Session/AccountStore.swift
+++ b/NioKit/Session/AccountStore.swift
@@ -159,9 +159,22 @@ public class AccountStore: ObservableObject {
 
     public var rooms: [NIORoom] {
         guard let session = self.session else { return [] }
-        UserDefaults.group.removeObject(forKey: "roomList")
-        return session.rooms
+
+        let rooms = session.rooms
             .map { roomCache[$0.id] ?? makeRoom(from: $0) }
             .sorted { $0.summary.lastMessageDate > $1.summary.lastMessageDate }
+
+        updateUserDefaults(with: rooms)
+        return rooms
+    }
+
+    private func updateUserDefaults(with rooms: [NIORoom]) {
+        let roomItems = rooms.map { RoomItem(room: $0.room) }
+        do {
+            let data = try JSONEncoder().encode(roomItems)
+            UserDefaults.group.set(data, forKey: "roomList")
+        } catch {
+            print("An error occured: \(error)")
+        }
     }
 }


### PR DESCRIPTION
#50 still stands with a delay from sending the message to it appearing, however when the room list wasn't showing, the messages rarely (ever?) showed up anyway. Turns out there was 1 instance of `NIORoom` listening for changes and that was different to the one being used for presentation.

I have added a room cache to the `AccountStore` (assuming in the future we may have multiple account stores for #45) and handled the user defaults refreshing in the same place.

I haven't been able to test the user defaults from the share sheet perspective yet. Otherwise I'm happy with this.