### PR TITLE
Tidy up minor warnings

### DIFF
--- a/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
@@ -101,10 +101,3 @@ struct MediaEventView: View {
                maxHeight: UIScreen.main.bounds.height * 0.75)
     }
 }
-
-// swiftlint:disable comment_spacing
-//struct MediaEventView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MediaEventView(model: .init(mediaURLs: [], timestamp: <#String#>))
-//    }
-//}

--- a/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
@@ -102,6 +102,7 @@ struct MediaEventView: View {
     }
 }
 
+// swiftlint:disable comment_spacing
 //struct MediaEventView_Previews: PreviewProvider {
 //    static var previews: some View {
 //        MediaEventView(model: .init(mediaURLs: [], timestamp: <#String#>))

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -171,6 +171,7 @@ struct RoomView: View {
     }
 }
 
+// swiftlint:disable comment_spacing
 //struct ConversationView_Previews: PreviewProvider {
 //    static var previews: some View {
 //        NavigationView {

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -170,14 +170,3 @@ struct RoomView: View {
         attributedMessage = NSAttributedString(string: "")
     }
 }
-
-// swiftlint:disable comment_spacing
-//struct ConversationView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        NavigationView {
-//            ConversationView()
-//                .accentColor(.purple)
-//                .navigationBarTitle("Morpheus", displayMode: .inline)
-//        }
-//    }
-//}

--- a/Nio/SceneDelegate.swift
+++ b/Nio/SceneDelegate.swift
@@ -2,7 +2,7 @@ import UIKit
 import SwiftUI
 
 import NioKit
-//swiftlint:disable line_length
+// swiftlint:disable line_length
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 

--- a/Nio/Shared Views/AttributedText.swift
+++ b/Nio/Shared Views/AttributedText.swift
@@ -79,7 +79,6 @@ struct TextAttributes {
         let clearsOnInsertion: Bool? = self.clearsOnInsertion ?? fallback.clearsOnInsertion
         let contentType: UITextContentType? = self.contentType ?? fallback.contentType
         let autocorrectionType: UITextAutocorrectionType? = self.autocorrectionType ?? fallback.autocorrectionType
-        // swiftlint:disable:next line_length
         let autocapitalizationType: UITextAutocapitalizationType? = self.autocapitalizationType ?? fallback.autocapitalizationType
         let lineLimit: Int? = self.lineLimit ?? fallback.lineLimit
         let lineBreakMode: NSLineBreakMode? = self.lineBreakMode ?? fallback.lineBreakMode

--- a/NioKit/Models/NIORoom.swift
+++ b/NioKit/Models/NIORoom.swift
@@ -117,7 +117,7 @@ public class NIORoom: ObservableObject {
     }
 
     public func redact(eventId: String, reason: String?) {
-        room.redactEvent(eventId, reason: reason) { response in
+        room.redactEvent(eventId, reason: reason) { _ in
             self.objectWillChange.send()
         }
     }

--- a/NioKit/Models/NIORoom.swift
+++ b/NioKit/Models/NIORoom.swift
@@ -84,7 +84,7 @@ public class NIORoom: ObservableObject {
 
     public func send(text: String) {
         guard !text.isEmpty else { return }
-        //swiftlint:disable:next redundant_optional_initialization
+        // swiftlint:disable:next redundant_optional_initialization
         var localEcho: MXEvent? = nil
         // TODO: Use localEcho to show sent message until it actually comes back
         room.sendTextMessage(text, localEcho: &localEcho) { _ in
@@ -96,7 +96,7 @@ public class NIORoom: ObservableObject {
     public func react(toEventId eventId: String, emoji: String) {
         // swiftlint:disable:next force_try
         let content = try! ReactionEvent(eventId: eventId, key: emoji).encodeContent()
-        //swiftlint:disable:next redundant_optional_initialization
+        // swiftlint:disable:next redundant_optional_initialization
         var localEcho: MXEvent? = nil
         room.sendEvent(.reaction, content: content, localEcho: &localEcho) { _ in
             self.objectWillChange.send()
@@ -105,7 +105,7 @@ public class NIORoom: ObservableObject {
 
     public func edit(text: String, eventId: String) {
         guard !text.isEmpty else { return }
-        //swiftlint:disable:next redundant_optional_initialization
+        // swiftlint:disable:next redundant_optional_initialization
         var localEcho: MXEvent? = nil
         // swiftlint:disable:next force_try
         let content = try! EditEvent(eventId: eventId, text: text).encodeContent()
@@ -124,7 +124,7 @@ public class NIORoom: ObservableObject {
 
     public func sendImage(image: UIImage) {
         guard let imageData = image.jpeg(.lowest) else { return }
-        //swiftlint:disable:next redundant_optional_initialization
+        // swiftlint:disable:next redundant_optional_initialization
         var localEcho: MXEvent? = nil
         // TODO: Use localEcho to show sent message until it actually comes back
         room.sendImage(

--- a/NioKit/Models/NIORoomSummary.swift
+++ b/NioKit/Models/NIORoomSummary.swift
@@ -6,8 +6,8 @@ public class NIORoomSummary: ObservableObject {
     internal var summary: MXRoomSummary
 
     public var lastMessageDate: Date {
-        let ts = Double(summary.lastMessageOriginServerTs)
-        return Date(timeIntervalSince1970: ts / 1000)
+        let timestamp = Double(summary.lastMessageOriginServerTs)
+        return Date(timeIntervalSince1970: timestamp / 1000)
     }
 
     public init(_ summary: MXRoomSummary) {

--- a/NioKit/Models/Reaction.swift
+++ b/NioKit/Models/Reaction.swift
@@ -27,7 +27,7 @@ public struct ReactionGroup: Identifiable {
     public var id: String {
         self.reaction
     }
-    
+
     public init(reaction: String, count: Int, reactions: [Reaction]) {
         self.reaction = reaction
         self.count = count

--- a/NioTests/EventCollectionTests.swift
+++ b/NioTests/EventCollectionTests.swift
@@ -4,7 +4,7 @@ import SwiftMatrixSDK
 @testable import Nio
 @testable import NioKit
 
-//swiftlint:disable identifier_name
+// swiftlint:disable identifier_name
 
 class EventCollectionTests: XCTestCase {
     func testReadConnectedEdges() {

--- a/NioTests/Mocks/MockEvent.swift
+++ b/NioTests/Mocks/MockEvent.swift
@@ -10,7 +10,7 @@ class MockEvent: MXEvent {
         self.originServerTs = 1000 * timestamp
     }
 
-    //swiftlint:disable:next identifier_name
+    // swiftlint:disable:next identifier_name
     var _type: String
     override var type: String! {
         _type

--- a/NioTests/RoomMemberEventViewTests.swift
+++ b/NioTests/RoomMemberEventViewTests.swift
@@ -19,7 +19,7 @@ class RoomMemberEventViewTests: XCTestCase {
     }
 
     // Disabled for now, see testKickEvent below.
-    //swiftlint:disable:next identifier_name
+    // swiftlint:disable:next identifier_name
     func _testWithdrawInviteEvent() {
         let withdrawInviteEvent = Model(
             sender: "Jane",
@@ -65,7 +65,7 @@ class RoomMemberEventViewTests: XCTestCase {
 
     // Disabled for now, since it can't be implemented until usernames are correctly handled.
     // Otherwise I'd show every leave event as a kick event 🤦‍♀️
-    //swiftlint:disable:next identifier_name
+    // swiftlint:disable:next identifier_name
     func _testKickEvent() throws {
         let kickEvent = Model(
             sender: "Jane",


### PR DESCRIPTION
Nothing major here, just reduces the number of warnings produced by swiftlint (ironically some of which were being produced by swiftlint related stuff 😆).