### PR TITLE
Don't install swiftlint in CI Action

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,7 +17,6 @@ jobs:
         xcodebuild -version
     - name: Prerequisites
       run: |
-        brew install swiftlint
         gem install cocoapods xcpretty
         pod install
     - name: Build


### PR DESCRIPTION
I've had 2 errors today that the CI action failed. Looks like it's failing installing swiftlint which is already [included](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#linters) (no idea why it's suddenly doing this today).