### PR TITLE
Fix signing issues on archive

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -1432,6 +1432,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Nio/Nio.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 27;
 				DEVELOPMENT_ASSET_PATHS = "\"Nio/Preview Content\"";
 				DEVELOPMENT_TEAM = HU85FER47E;
@@ -1444,6 +1446,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = chat.nio.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1455,6 +1458,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NioShareExtension/NioShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 27;
 				INFOPLIST_FILE = NioShareExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1475,6 +1479,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NioShareExtension/NioShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 27;
+				DEVELOPMENT_TEAM = HU85FER47E;
 				INFOPLIST_FILE = NioShareExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1482,7 +1490,9 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = chat.nio.iOS.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;

--- a/Nio/Info.plist
+++ b/Nio/Info.plist
@@ -62,6 +62,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>DevelopmentTeam</key>
+	<string>$(DEVELOPMENT_TEAM)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>
@@ -81,8 +83,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>DevelopmentTeam</key>
-	<string>$(DEVELOPMENT_TEAM)</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Nio/Nio.entitlements
+++ b/Nio/Nio.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(APPGROUP)</string>
+		<string>group.chat.nio.group</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/NioShareExtension/Info.plist
+++ b/NioShareExtension/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppGroup</key>
+	<string>$(APPGROUP)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -19,9 +21,9 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>AppGroup</key>
-	<string>$(APPGROUP)</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>DevelopmentTeam</key>
+	<string>$(DEVELOPMENT_TEAM)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>
@@ -41,7 +43,5 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>ShareNavigationController</string>
 	</dict>
-	<key>DevelopmentTeam</key>
-	<string>$(DEVELOPMENT_TEAM)</string>
 </dict>
 </plist>

--- a/NioShareExtension/NioShareExtension.entitlements
+++ b/NioShareExtension/NioShareExtension.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(APPGROUP)</string>
+		<string>group.chat.nio.group</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>


### PR DESCRIPTION
Apparently it's not (no longer?) possible to use variables in entitlements files. So those now contain the explicit new group identifier. The old one apparently isn't registered to my AppleID anymore, so I can't use that any more 😕 

Also the new bundle identifier for the share extensions apparently also has to be listed in the project file. Weird. 

Some other keys just got shifted around, because apparently stable key sorting isn't something that would be cool for a plist file 🙈 I committed those changes as well in the hope that they'll stay the same now.

@pixlwave Could you try and build this locally and see if everything still works for you? Thanks!