### PR TITLE
Load more messages

### DIFF
--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -89,6 +89,7 @@ struct RoomContainerView: View {
 struct RoomView: View {
     @Environment(\.userId) var userId
     @EnvironmentObject var room: NIORoom
+    @EnvironmentObject var store: AccountStore
 
     var events: EventCollection
     var isDirect: Bool
@@ -106,6 +107,8 @@ struct RoomView: View {
     @State private var highlightMessage: String?
     @State private var isEditingMessage: Bool = false
     @State private var attributedMessage = NSAttributedString(string: "")
+
+    @State private var firstMessage = false
 
     var body: some View {
         VStack {
@@ -129,6 +132,12 @@ struct RoomView: View {
                                         }
                                     }))
                     .padding(.horizontal)
+                    .onAppear(perform: {
+                        if !self.firstMessage {
+                            self.firstMessage = true
+                            self.store.pagenate(room: self.room, event: event)
+                        }
+                    })
             }
             if !(room.room.typingUsers?.filter { $0 != userId }.isEmpty ?? false) {
                 TypingIndicatorContainerView()

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -133,9 +133,8 @@ struct RoomView: View {
                                     }))
                     .padding(.horizontal)
                     .onAppear(perform: {
-                        if !self.firstMessage {
-                            self.firstMessage = true
-                            self.store.pagenate(room: self.room, event: event)
+                        if self.events.renderableEventsWithoutEdited.first!.eventId == event.eventId! {
+                            self.store.paginate(room: self.room, event: event)
                         }
                     })
             }

--- a/Nio/Shared Views/ReverseList.swift
+++ b/Nio/Shared Views/ReverseList.swift
@@ -10,16 +10,19 @@ struct ReverseList<Element, Content>: View where Element: Identifiable, Content:
         self.items = items
         self.reverseItemOrder = reverseItemOrder
         self.viewForItem = viewForItem
+        UITableView.appearance().separatorStyle = .none
     }
 
     var body: some View {
-        ScrollView {
+        List {
             ForEach(reverseItemOrder ? items.reversed() : items) { item in
                 self.viewForItem(item)
                     .scaleEffect(x: -1.0, y: 1.0)
                     .rotationEffect(.degrees(180))
             }
         }
+        .environment(\.defaultMinListRowHeight, 0)
+        .padding(.horizontal, -15)
         .scaleEffect(x: -1.0, y: 1.0)
         .rotationEffect(.degrees(180))
     }

--- a/Nio/Shared Views/ReverseList.swift
+++ b/Nio/Shared Views/ReverseList.swift
@@ -10,19 +10,18 @@ struct ReverseList<Element, Content>: View where Element: Identifiable, Content:
         self.items = items
         self.reverseItemOrder = reverseItemOrder
         self.viewForItem = viewForItem
-        UITableView.appearance().separatorStyle = .none
     }
 
     var body: some View {
-        List {
-            ForEach(reverseItemOrder ? items.reversed() : items) { item in
-                self.viewForItem(item)
-                    .scaleEffect(x: -1.0, y: 1.0)
-                    .rotationEffect(.degrees(180))
+        ScrollView {
+            LazyVStack {
+                ForEach(reverseItemOrder ? items.reversed() : items) { item in
+                    self.viewForItem(item)
+                        .scaleEffect(x: -1.0, y: 1.0)
+                        .rotationEffect(.degrees(180))
+                }
             }
         }
-        .environment(\.defaultMinListRowHeight, 0)
-        .padding(.horizontal, -15)
         .scaleEffect(x: -1.0, y: 1.0)
         .rotationEffect(.degrees(180))
     }

--- a/Nio/Shared Views/ReverseList.swift
+++ b/Nio/Shared Views/ReverseList.swift
@@ -1,35 +1,61 @@
 import SwiftUI
 import UIKit
 
+struct IsVisibleKey: PreferenceKey {
+    static var defaultValue: Bool = false
+
+    static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = nextValue()
+    }
+}
+
 struct ReverseList<Element, Content>: View where Element: Identifiable, Content: View {
     var items: [Element]
     var reverseItemOrder: Bool
     var viewForItem: (Element) -> Content
 
-    init(_ items: [Element], reverseItemOrder: Bool = true, viewForItem: @escaping (Element) -> Content) {
+    @Binding var hasReachedTop: Bool
+
+    init(_ items: [Element], reverseItemOrder: Bool = true, hasReachedTop: Binding<Bool>, viewForItem: @escaping (Element) -> Content) {
         self.items = items
         self.reverseItemOrder = reverseItemOrder
+        self._hasReachedTop = hasReachedTop
         self.viewForItem = viewForItem
     }
 
     var body: some View {
-        ScrollView {
-            LazyVStack {
+        GeometryReader { contentsGeometry in
+            ScrollView {
                 ForEach(reverseItemOrder ? items.reversed() : items) { item in
                     self.viewForItem(item)
                         .scaleEffect(x: -1.0, y: 1.0)
                         .rotationEffect(.degrees(180))
                 }
+                GeometryReader { topViewGeometry in
+                    let frame = topViewGeometry.frame(in: .global)
+                    let isVisible = contentsGeometry.frame(in: .global).contains(CGPoint(x: frame.midX, y: frame.midY))
+
+                    HStack {
+                        Spacer()
+                        ProgressView().progressViewStyle(CircularProgressViewStyle())
+                        Spacer()
+                    }
+                    .preference(key: IsVisibleKey.self, value: isVisible)
+                }
+                .frame(height: 30)      // FIXME: Frame height shouldn't be hard-coded
+                .onPreferenceChange(IsVisibleKey.self) {
+                    hasReachedTop = $0
+                }
             }
+            .scaleEffect(x: -1.0, y: 1.0)
+            .rotationEffect(.degrees(180))
         }
-        .scaleEffect(x: -1.0, y: 1.0)
-        .rotationEffect(.degrees(180))
     }
 }
 
 struct ReverseList_Previews: PreviewProvider {
     static var previews: some View {
-        ReverseList(["1", "2", "3"]) {
+        ReverseList(["1", "2", "3"], hasReachedTop: .constant(false)) {
             Text($0)
         }
     }

--- a/NioKit/Models/EventCollection.swift
+++ b/NioKit/Models/EventCollection.swift
@@ -22,7 +22,7 @@ public struct EventCollection {
         wrapped.filter { Self.renderableEventTypes.contains($0.type) }
     }
 
-    var renderableEventsWithoutEdited: [MXEvent] {
+    public var renderableEventsWithoutEdited: [MXEvent] {
         wrapped.filter { Self.renderableEventTypes.contains($0.type) && !$0.isEdit()}
     }
 

--- a/NioKit/Models/EventCollection.swift
+++ b/NioKit/Models/EventCollection.swift
@@ -22,10 +22,6 @@ public struct EventCollection {
         wrapped.filter { Self.renderableEventTypes.contains($0.type) }
     }
 
-    public var renderableEventsWithoutEdited: [MXEvent] {
-        wrapped.filter { Self.renderableEventTypes.contains($0.type) && !$0.isEdit()}
-    }
-
     public func relatedEvents(of event: MXEvent) -> [MXEvent] {
         wrapped.filter { $0.relatesTo?.eventId == event.eventId }
     }

--- a/NioKit/Models/EventCollection.swift
+++ b/NioKit/Models/EventCollection.swift
@@ -22,6 +22,10 @@ public struct EventCollection {
         wrapped.filter { Self.renderableEventTypes.contains($0.type) }
     }
 
+    var renderableEventsWithoutEdited: [MXEvent] {
+        wrapped.filter { Self.renderableEventTypes.contains($0.type) && !$0.isEdit()}
+    }
+
     public func relatedEvents(of event: MXEvent) -> [MXEvent] {
         wrapped.filter { $0.relatesTo?.eventId == event.eventId }
     }

--- a/NioKit/Session/AccountStore.swift
+++ b/NioKit/Session/AccountStore.swift
@@ -177,4 +177,26 @@ public class AccountStore: ObservableObject {
             print("An error occured: \(error)")
         }
     }
+
+    var listenReferenceRoom: Any?
+
+    func pagenate(room: NIORoom, event: MXEvent) {
+        room.room.liveTimeline { timeline in
+            self.listenReferenceRoom = timeline?.listenToEvents { event, direction, roomState in
+                print(event)
+                room.add(event: event, direction: direction, roomState: roomState)
+                self.objectWillChange.send()
+            }
+            timeline?.resetPagination()
+            let canPage = timeline?.canPaginate(.backwards) ?? false
+            if canPage {
+                timeline?.paginate(20, direction: .backwards, onlyFromStore: false) {response in
+                    if response.isSuccess {
+                        print(response.value)
+                        //room.add(event: response.value, direction: .backwards, roomState: nil)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/NioKit/Session/AccountStore.swift
+++ b/NioKit/Session/AccountStore.swift
@@ -180,7 +180,7 @@ public class AccountStore: ObservableObject {
 
     var listenReferenceRoom: Any?
 
-    func paginate(room: NIORoom, event: MXEvent) {
+    public func paginate(room: NIORoom, event: MXEvent) {
         let timeline = room.room.timeline(onEvent: event.eventId)
         listenReferenceRoom = timeline?.listenToEvents { event, direction, roomState in
             if direction == .backwards {


### PR DESCRIPTION
This seems to be working well for me. @stefanhofman's  original pagination implementation is great, all that I've done is reverted back to a regular `VStack` (after trying a `LazyVStack`) as it doesn't seem to be recommended to use a list or lazy stack for content with variable content size (also it doesn't seem possible to hide the table view separators on a `List` since iOS 14 so that was a dead end).

I added a `ProgressView` spinner at the top of the list which triggers the pagination whenever it comes into view. Needs some future work to hide the spinner if there's no more messages to load.