### PR TITLE
Fix message size

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		4BFEFD8C246F458000CCF4A0 /* GetURL.js in Resources */ = {isa = PBXBuildFile; fileRef = 4BFEFD8B246F458000CCF4A0 /* GetURL.js */; };
 		4BFEFD92246F686000CCF4A0 /* ShareContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEFD91246F686000CCF4A0 /* ShareContentView.swift */; };
 		A51BF8CE254C2FE5000FB0A4 /* NioApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51BF8CD254C2FE5000FB0A4 /* NioApp.swift */; };
+		A51F762C25D6E9950061B4A4 /* MessageTextViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51F762B25D6E9950061B4A4 /* MessageTextViewWrapper.swift */; };
 		A58352A625A667AB00533363 /* MatrixSDK in Frameworks */ = {isa = PBXBuildFile; productRef = A58352A525A667AB00533363 /* MatrixSDK */; };
 		A58352AC25A667B300533363 /* MatrixSDK in Frameworks */ = {isa = PBXBuildFile; productRef = A58352AB25A667B300533363 /* MatrixSDK */; };
 		CAAF5BF82478696F006FDC33 /* UITextViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAF5BF72478696F006FDC33 /* UITextViewWrapper.swift */; };
@@ -272,6 +273,7 @@
 		4BFEFD90246F5EF500CCF4A0 /* Nio.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Nio.entitlements; sourceTree = "<group>"; };
 		4BFEFD91246F686000CCF4A0 /* ShareContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareContentView.swift; sourceTree = "<group>"; };
 		A51BF8CD254C2FE5000FB0A4 /* NioApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NioApp.swift; sourceTree = "<group>"; };
+		A51F762B25D6E9950061B4A4 /* MessageTextViewWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageTextViewWrapper.swift; sourceTree = "<group>"; };
 		CAAF5BF72478696F006FDC33 /* UITextViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextViewWrapper.swift; sourceTree = "<group>"; };
 		CAC46D5423A272D10079C24F /* BorderlessMessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderlessMessageView.swift; sourceTree = "<group>"; };
 		CAC46D5523A272D10079C24F /* MessageViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageViewModel.swift; sourceTree = "<group>"; };
@@ -469,6 +471,7 @@
 				CAF2AE882458EEBB00D84133 /* AttributedText.swift */,
 				CAF2AE8A2458EF0900D84133 /* MarkdownText.swift */,
 				4B0A2E46245E2EF800A79443 /* MultilineTextField.swift */,
+				A51F762B25D6E9950061B4A4 /* MessageTextViewWrapper.swift */,
 				CAAF5BF72478696F006FDC33 /* UITextViewWrapper.swift */,
 				4B29F5B42466EC240084043B /* ImagePicker.swift */,
 			);
@@ -1098,6 +1101,7 @@
 				CADF662424614A3300F5063F /* ReactionGroupView.swift in Sources */,
 				392221B6243F88FD004D8794 /* RoomNameEventView.swift in Sources */,
 				4B0A2E47245E2EF800A79443 /* MultilineTextField.swift in Sources */,
+				A51F762C25D6E9950061B4A4 /* MessageTextViewWrapper.swift in Sources */,
 				A51BF8CE254C2FE5000FB0A4 /* NioApp.swift in Sources */,
 				3902B8A0239410EE00698B87 /* ContentSizeCategory.swift in Sources */,
 				39D166C62385C804006DD257 /* String+Emoji.swift in Sources */,

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -78,12 +78,9 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
 
     var markdownView: some View {
         MarkdownText(
-            markdown: .constant(model.text),
+            markdown: model.text,
             textColor: .messageTextColor(for: colorScheme, isOutgoing: isMe),
-            linkTextAttributes: [
-                .foregroundColor: linkColor,
-                .underlineStyle: NSUnderlineStyle.single.rawValue,
-            ]
+            linkColor: linkColor
         ) { url, _ in
             print("Tapped URL:", url)
             return true

--- a/Nio/Shared Views/MessageTextViewWrapper.swift
+++ b/Nio/Shared Views/MessageTextViewWrapper.swift
@@ -17,6 +17,7 @@ class MessageTextView: UITextView {
         backgroundColor = .clear
         textContainerInset = .zero
         textContainer.lineFragmentPadding = 0
+        dataDetectorTypes = .all
         isEditable = false
         isScrollEnabled = false
         linkTextAttributes = [

--- a/Nio/Shared Views/MessageTextViewWrapper.swift
+++ b/Nio/Shared Views/MessageTextViewWrapper.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// An automatically sized label, which allows links to be tapped.
+class MessageTextView: UITextView {
+    var maxSize: CGSize = .zero
+
+    // Allows SwiftUI to automatically size the label appropriately
+    override var intrinsicContentSize: CGSize {
+        sizeThatFits(CGSize(width: maxSize.width, height: .infinity))
+    }
+
+    convenience init(attributedString: NSAttributedString, linkColor: UIColor, maxSize: CGSize) {
+        self.init()
+
+        font = UIFont.preferredFont(forTextStyle: .body)
+        textColor = UIColor.label
+        backgroundColor = .clear
+        textContainerInset = .zero
+        textContainer.lineFragmentPadding = 0
+        isEditable = false
+        isScrollEnabled = false
+        linkTextAttributes = [
+            .foregroundColor: linkColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+
+        attributedText = attributedString
+        self.maxSize = maxSize
+
+        // don't resist text wrapping across multiple lines
+        setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    }
+}
+
+struct MessageTextViewWrapper: UIViewRepresentable {
+    let attributedString: NSAttributedString
+    let linkColor: UIColor
+    let maxSize: CGSize
+
+    func makeUIView(context: Context) -> MessageTextView {
+        MessageTextView(attributedString: attributedString, linkColor: linkColor, maxSize: maxSize)
+    }
+
+    func updateUIView(_ uiView: MessageTextView, context: Context) {
+        // nothing to update
+    }
+
+    func makeCoordinator() {
+        // nothing to coordinate
+    }
+}


### PR DESCRIPTION
Adds a `MessageTextView` (non-editable `UITextView` subclass) just for messages along with a `MessageTextViewWrapper`.

The sizing is now handled before display so it fixes the funky animation between the local echo and the remote message coming in. Additionally this fixes the Catalyst message flickering 😄

Also, I noticed that it was one line to enable data detectors, so now regular URLs, phone numbers, dates etc are all tappable 🎉

<img width="300" alt="Screenshot 2021-02-12 at 6 08 17 pm" src="https://user-images.githubusercontent.com/6060466/107805457-4a3f9880-6d5d-11eb-8b96-20f21217456f.png">