### PR TITLE
Conditionally flip message view contents

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		392389CC238EBB1500B2E1DF /* ReverseList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392389CB238EBB1400B2E1DF /* ReverseList.swift */; };
 		393411D1239087D2003B49B8 /* EventCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 393411D0239087D2003B49B8 /* EventCollectionTests.swift */; };
 		3964D5D625C4BB8600617C35 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3964D5CC25C4BB0200617C35 /* Configuration.swift */; };
+		396F072F25D94BEC00C9907A /* FlipGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396F072E25D94BEC00C9907A /* FlipGroup.swift */; };
 		3984654523B7ECBA006C173B /* MXURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3984654423B7ECBA006C173B /* MXURL.swift */; };
 		3984654823B8D809006C173B /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 3984654723B8D809006C173B /* SDWebImageSwiftUI */; };
 		39B834C0243FC42000AE1EA0 /* TypingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B834BF243FC42000AE1EA0 /* TypingIndicatorView.swift */; };
@@ -234,6 +235,7 @@
 		3955DD36245C371C00827F07 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		395DDC1825C0C2D6002FC413 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3964D5CC25C4BB0200617C35 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		396F072E25D94BEC00C9907A /* FlipGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipGroup.swift; sourceTree = "<group>"; };
 		3984654423B7ECBA006C173B /* MXURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MXURL.swift; sourceTree = "<group>"; };
 		3997DCCF245732F000763C07 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		39B834BF243FC42000AE1EA0 /* TypingIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingIndicatorView.swift; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				A51F762B25D6E9950061B4A4 /* MessageTextViewWrapper.swift */,
 				CAAF5BF72478696F006FDC33 /* UITextViewWrapper.swift */,
 				4B29F5B42466EC240084043B /* ImagePicker.swift */,
+				396F072E25D94BEC00C9907A /* FlipGroup.swift */,
 			);
 			path = "Shared Views";
 			sourceTree = "<group>";
@@ -1094,6 +1097,7 @@
 				CAFCB323245F6E6700869320 /* NSAttributedString+Extensions.swift in Sources */,
 				CAF2AE892458EEBC00D84133 /* AttributedText.swift in Sources */,
 				CAC46D5B23A2734C0079C24F /* EnvironmentValues.swift in Sources */,
+				396F072F25D94BEC00C9907A /* FlipGroup.swift in Sources */,
 				39C932072384BB13004449E1 /* RecentRoomsView.swift in Sources */,
 				CAC46D6F23A56BBE0079C24F /* GroupingIterator.swift in Sources */,
 				392221B2243D0CCC004D8794 /* RoomTopicEventView.swift in Sources */,

--- a/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
@@ -87,22 +87,14 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
 
     var bodyView: some View {
         VStack(alignment: isMe ? .trailing : .leading, spacing: 0) {
-            if isMe {
-                HStack {
-                    if !self.connectedEdges.contains(.bottomEdge) {
-                        self.timestampView
-                   }
-                    self.conditionalBadgedContentView
-                }
-            } else {
-                HStack {
+            HStack {
+                FlipGroup(flippedIf: isMe) {
                     self.conditionalBadgedContentView
                     if !self.connectedEdges.contains(.bottomEdge) {
                         self.timestampView
                     }
                 }
             }
-
             GroupedReactionsView(reactions: model.reactions)
         }
     }

--- a/Nio/Shared Views/FlipGroup.swift
+++ b/Nio/Shared Views/FlipGroup.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+// Credit goes to https://stackoverflow.com/a/62652866/1843020
+
+// swiftlint:disable:next identifier_name
+@ViewBuilder func FlipGroup<V1: View, V2: View>(
+    flippedIf condition: Bool,
+    @ViewBuilder _ content: @escaping () -> TupleView<(V1, V2)>
+) -> some View {
+    let pair = content()
+    if condition {
+        TupleView((pair.value.1, pair.value.0))
+    } else {
+        TupleView((pair.value.0, pair.value.1))
+    }
+}
+
+struct FlipGroup_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            HStack {
+                FlipGroup(flippedIf: false) {
+                    Text("A")
+                    Text("B")
+                }
+            }
+
+            HStack {
+                FlipGroup(flippedIf: true) {
+                    Text("A")
+                    Text("B")
+                }
+            }
+        }
+        .previewLayout(.sizeThatFits)
+    }
+}


### PR DESCRIPTION
This should help minimize the code duplication we have for aligning bubbles based on if their incoming or outgoing messages. Seems to work great, but I've only tried it with the `BorderlessMessageView` for a quick test.