### PR TITLE
Keyboard tweaks

### DIFF
--- a/Nio/Conversations/MessageComposerView.swift
+++ b/Nio/Conversations/MessageComposerView.swift
@@ -29,6 +29,12 @@ struct MessageComposerView: View {
     var onCancel: () -> Void
     var onCommit: () -> Void
 
+    #if targetEnvironment(macCatalyst)
+    let returnCommits = true
+    #else
+    let returnCommits = false
+    #endif
+
     var backgroundColor: Color {
         colorScheme == .light ? Color(#colorLiteral(red: 0.9332506061, green: 0.937307477, blue: 0.9410644174, alpha: 1)) : Color(#colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1))
     }
@@ -106,7 +112,8 @@ struct MessageComposerView: View {
             attributedText: $attributedMessage,
             placeholder: L10n.Composer.newMessage,
             isEditing: self.$isEditing,
-            textAttributes: TextAttributes(autocapitalizationType: .sentences)
+            textAttributes: TextAttributes(autocapitalizationType: .sentences),
+            onCommit: returnCommits ? onCommit : nil
         )
         .background(self.background)
         .onPreferenceChange(ContentSizeThatFitsKey.self) {

--- a/Nio/Conversations/MessageComposerView.swift
+++ b/Nio/Conversations/MessageComposerView.swift
@@ -105,7 +105,8 @@ struct MessageComposerView: View {
         MultilineTextField(
             attributedText: $attributedMessage,
             placeholder: L10n.Composer.newMessage,
-            isEditing: self.$isEditing
+            isEditing: self.$isEditing,
+            textAttributes: TextAttributes(autocapitalizationType: .sentences)
         )
         .background(self.background)
         .onPreferenceChange(ContentSizeThatFitsKey.self) {

--- a/Nio/Shared Views/UITextViewWrapper.swift
+++ b/Nio/Shared Views/UITextViewWrapper.swift
@@ -1,7 +1,35 @@
 import SwiftUI
 
 struct UITextViewWrapper: UIViewRepresentable {
-    typealias UIViewType = UITextView
+    class TextView: UITextView {
+        private let newLineModifiers: [UIKeyboardHIDUsage] = [
+            .keyboardLeftShift,
+            .keyboardRightShift,
+            .keyboardLeftAlt,
+            .keyboardRightAlt
+        ]
+
+        private var currentModifiers: Set<UIKeyboardHIDUsage> = []
+        var shouldCommit: Bool { currentModifiers.isEmpty }
+
+        private func newLineKeyCodes(in presses: Set<UIPress>) -> [UIKeyboardHIDUsage] {
+            presses.compactMap { $0.key?.keyCode }.filter { newLineModifiers.contains($0) }
+        }
+
+        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            super.pressesBegan(presses, with: event)
+
+            let keyCodes = newLineKeyCodes(in: presses)
+            keyCodes.forEach { currentModifiers.insert($0) }
+        }
+
+        override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            super.pressesEnded(presses, with: event)
+
+            let keyCodes = newLineKeyCodes(in: presses)
+            keyCodes.forEach { currentModifiers.remove($0) }
+        }
+    }
 
     @Environment(\.textAttributes)
     var envTextAttributes: TextAttributes
@@ -42,8 +70,8 @@ struct UITextViewWrapper: UIViewRepresentable {
     }
 
     // swiftlint:disable:next cyclomatic_complexity
-    func makeUIView(context: Context) -> UITextView {
-        let view = UITextView()
+    func makeUIView(context: Context) -> TextView {
+        let view = TextView()
 
         view.delegate = context.coordinator
 
@@ -107,7 +135,7 @@ struct UITextViewWrapper: UIViewRepresentable {
         return view
     }
 
-    func updateUIView(_ uiView: UITextView, context: Context) {
+    func updateUIView(_ uiView: TextView, context: Context) {
         uiView.attributedText = attributedText
         if isEditing {
             uiView.becomeFirstResponder()
@@ -206,8 +234,6 @@ struct UITextViewWrapper: UIViewRepresentable {
                 }
                 self.isEditing = false
             }
-
-            onCommit?()
         }
 
         func textView(
@@ -224,12 +250,18 @@ struct UITextViewWrapper: UIViewRepresentable {
             shouldChangeTextIn range: NSRange,
             replacementText text: String
         ) -> Bool {
-            guard let onCommit = self.onCommit, text == "\n" else {
+            guard
+                text == "\n",
+                let onCommit = onCommit,
+                let view = textView as? TextView,
+                view.shouldCommit
+            else {
                 return true
             }
 
-            textView.resignFirstResponder()
-            onCommit()
+            DispatchQueue.main.async {
+                onCommit()
+            }
 
             return false
         }

--- a/Nio/Shared Views/UITextViewWrapper.swift
+++ b/Nio/Shared Views/UITextViewWrapper.swift
@@ -253,8 +253,8 @@ struct UITextViewWrapper: UIViewRepresentable {
             guard
                 text == "\n",
                 let onCommit = onCommit,
-                let view = textView as? TextView,
-                view.shouldCommit
+                let textView = textView as? TextView,
+                textView.shouldCommit
             else {
                 return true
             }


### PR DESCRIPTION
Fixes #249 and #250 🎉

Edit: For 249, on Mac only, ↵ sends and ⇧↵ or ⌥↵ both insert a new line.