### PR TITLE
Add iPad Keyboard to #249

### DIFF
--- a/Nio/Conversations/MessageComposerView.swift
+++ b/Nio/Conversations/MessageComposerView.swift
@@ -29,12 +29,6 @@ struct MessageComposerView: View {
     var onCancel: () -> Void
     var onCommit: () -> Void
 
-    #if targetEnvironment(macCatalyst)
-    let returnCommits = true
-    #else
-    let returnCommits = false
-    #endif
-
     var backgroundColor: Color {
         colorScheme == .light ? Color(#colorLiteral(red: 0.9332506061, green: 0.937307477, blue: 0.9410644174, alpha: 1)) : Color(#colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1))
     }
@@ -113,7 +107,7 @@ struct MessageComposerView: View {
             placeholder: L10n.Composer.newMessage,
             isEditing: self.$isEditing,
             textAttributes: TextAttributes(autocapitalizationType: .sentences),
-            onCommit: returnCommits ? onCommit : nil
+            onCommit: onCommit
         )
         .background(self.background)
         .onPreferenceChange(ContentSizeThatFitsKey.self) {


### PR DESCRIPTION
Annoyingly, for some reason Catalyst only seems to be sending some keystrokes to `pressesBegan`/`Ended` so the implementation can't be universally kept in there. Not sure if it can get much better than this 😕

Note: I can only test this on the simulator, but can confirm it doesn't impact the software keyboard on a device.