### PR TITLE
Modify The Edit Button on NewConversationView

### DIFF
--- a/Nio/Generated/Strings.swift
+++ b/Nio/Generated/Strings.swift
@@ -172,6 +172,10 @@ internal enum L10n {
     internal static let cancel = L10n.tr("Localizable", "new-conversation.cancel")
     /// Start Chat
     internal static let createRoom = L10n.tr("Localizable", "new-conversation.create-room")
+    /// Done
+    internal static let done = L10n.tr("Localizable", "new-conversation.done")
+    /// Edit
+    internal static let edit = L10n.tr("Localizable", "new-conversation.edit")
     /// For example
     internal static let forExample = L10n.tr("Localizable", "new-conversation.for-example")
     /// Public Room

--- a/Nio/NewConversation/NewConversationView.swift
+++ b/Nio/NewConversation/NewConversationView.swift
@@ -18,6 +18,7 @@ struct NewConversationView: View {
     var store: AccountStore?
 
     @State private var users = [""]
+    @State private var editMode = EditMode.inactive
     @State private var roomName = ""
     @State private var isPublic = false
 
@@ -77,6 +78,10 @@ struct NewConversationView: View {
                           message: Text(errorMessage))
                 }
             }
+            .environment(\.editMode, $editMode)
+            .onChange(of: users.count) { count in
+                editMode = count > 1 ? editMode : .inactive
+            }
             .disabled(isWaiting)
             .navigationTitle(users.count > 1 ? L10n.NewConversation.titleRoom : L10n.NewConversation.titleChat)
             .navigationBarTitleDisplayMode(.inline)
@@ -88,7 +93,14 @@ struct NewConversationView: View {
                 }
                 ToolbarItem(placement: .automatic) {
                     if users.count > 1 {
-                        EditButton()
+                        // It seems that `.environment(\.editMode, $editMode)`
+                        // and `EditButton` cannot coexist.
+                        Button(editMode.isEditing
+                                ? L10n.NewConversation.done
+                                : L10n.NewConversation.edit
+                        ) {
+                            editMode = editMode.isEditing ? .inactive : .active
+                        }
                     }
                 }
             }

--- a/Nio/NewConversation/NewConversationView.swift
+++ b/Nio/NewConversation/NewConversationView.swift
@@ -25,10 +25,6 @@ struct NewConversationView: View {
     @Binding var createdRoomId: ObjectIdentifier?
     @State private var errorMessage: String?
 
-    var usersHeader: some View {
-        EditButton().frame(maxWidth: .infinity, alignment: .trailing)
-    }
-
     var usersFooter: some View {
         Text("\(L10n.NewConversation.forExample) \(store?.session?.myUserId ?? "@username:server.org")")
     }
@@ -36,7 +32,7 @@ struct NewConversationView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: usersHeader, footer: usersFooter) {
+                Section(footer: usersFooter) {
                     ForEach(0..<users.count, id: \.self) { index in
                         HStack {
                             TextField(L10n.NewConversation.usernamePlaceholder,
@@ -88,6 +84,11 @@ struct NewConversationView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(L10n.NewConversation.cancel) {
                         presentationMode.wrappedValue.dismiss()
+                    }
+                }
+                ToolbarItem(placement: .automatic) {
+                    if users.count > 1 {
+                        EditButton()
                     }
                 }
             }

--- a/Nio/Supporting Files/en.lproj/Localizable.strings
+++ b/Nio/Supporting Files/en.lproj/Localizable.strings
@@ -87,3 +87,5 @@
 "new-conversation.create-room" = "Start Chat";
 "new-conversation.alert-failed" = "Failed To Start Chat";
 "new-conversation.cancel" = "Cancel";
+"new-conversation.edit" = "Edit";
+"new-conversation.done" = "Done";


### PR DESCRIPTION
This pull request
- moves the edit button to the navigation bar;
- hides the edit button when there is only one account.