### PR TITLE
Drop use of `AnyView`, fix property mutability and visibility

### DIFF
--- a/Nio/Authentication/LoadingView.swift
+++ b/Nio/Authentication/LoadingView.swift
@@ -3,23 +3,23 @@ import SwiftUI
 import NioKit
 
 struct LoadingView: View {
-    @EnvironmentObject var store: AccountStore
+    @EnvironmentObject private var store: AccountStore
 
-    var loadingEmoji = [
+    private let loadingEmoji = [
         "🧑‍🎤",
         "🧑‍🏭",
         "🧑‍🔧",
         "🧑‍💻",
     ]
 
-    var loadingMessages = [
+    private let loadingMessages = [
         L10n.Loading._1,
         L10n.Loading._2,
         L10n.Loading._3,
         L10n.Loading._4,
     ]
 
-    var randomLoadingMessage: String {
+    private var randomLoadingMessage: String {
         "\(loadingEmoji.randomElement()!) \(loadingMessages.randomElement()!)"
     }
 
@@ -35,11 +35,10 @@ struct LoadingView: View {
 
             Spacer()
 
-            Button(action: {
-                self.store.logout()
-            }, label: {
+            Button(action: self.store.logout) {
                 Text(L10n.Loading.cancel).font(.callout)
-            }).padding()
+            }
+            .padding()
         }
     }
 }

--- a/Nio/Authentication/LoginView.swift
+++ b/Nio/Authentication/LoginView.swift
@@ -92,7 +92,7 @@ struct LoginView: View {
         }
     }
 
-    var buttons: some View {
+    private var buttons: some View {
         VStack {
             Button(action: {
                 self.onLogin()
@@ -150,9 +150,9 @@ struct LoginForm: View {
 }
 
 private struct FormTextField: View {
-    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.colorScheme) private var colorScheme
 
-    var title: String
+    let title: String
     @Binding var text: String
     var onEditingChanged: ((Bool) -> Void)?
 

--- a/Nio/Conversations/ContextMenu/EventContextMenu.swift
+++ b/Nio/Conversations/ContextMenu/EventContextMenu.swift
@@ -2,14 +2,14 @@ import SwiftUI
 import MatrixSDK
 
 private struct EventContextMenuViewModel {
-    var canReact: Bool
-    var canReply: Bool
-    var canEdit: Bool
-    var canRedact: Bool
+    fileprivate let canReact: Bool
+    fileprivate let canReply: Bool
+    fileprivate let canEdit: Bool
+    fileprivate let canRedact: Bool
 
     init(event: MXEvent, userId: String) {
         var canReact = false
-        var canReply = false
+        let canReply = false
         var canEdit = false
         var canRedact = false
 
@@ -48,10 +48,10 @@ struct EventContextMenu: View {
 
     typealias Action = () -> Void
 
-    var onReact: Action
-    var onReply: Action
-    var onEdit: Action
-    var onRedact: Action
+    private let onReact: Action
+    private let onReply: Action
+    private let onEdit: Action
+    private let onRedact: Action
 
     init(model: EventContextMenuModel) {
         self.init(event: model.event,

--- a/Nio/Conversations/ContextMenu/ReactionPicker.swift
+++ b/Nio/Conversations/ContextMenu/ReactionPicker.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ReactionPicker: View {
     let emoji = ["👍", "👎", "😄", "🎉", "❤️", "🚀", "👀"]
 
-    var picked: (String) -> Void
+    let picked: (String) -> Void
 
     var body: some View {
         VStack {

--- a/Nio/Conversations/Event Views/GenericEventView.swift
+++ b/Nio/Conversations/Event Views/GenericEventView.swift
@@ -4,11 +4,11 @@ import SDWebImageSwiftUI
 import NioKit
 
 struct GenericEventView: View {
-    @EnvironmentObject var store: AccountStore
+    @EnvironmentObject private var store: AccountStore
 
-    var text: String
+    let text: String
     var image: MXURL?
-    var imageURL: URL? {
+    private var imageURL: URL? {
         return store.client?.homeserver
             .flatMap(URL.init(string:))
             .flatMap { image?.contentURL(on: $0) }

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -87,16 +87,12 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         }
     }
 
-    var senderView: some View {
+    @ViewBuilder private var senderView: some View {
         if model.showSender
             && !isMe
             && (connectedEdges.isEmpty || connectedEdges == .bottomEdge) {
-                return AnyView(
                     Text(model.sender)
                         .font(.caption)
-                )
-        } else {
-            return AnyView(EmptyView())
         }
     }
 

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -4,17 +4,17 @@ import MatrixSDK
 import NioKit
 
 struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
-    @Environment(\.colorScheme) var colorScheme
-    @Environment(\.colorSchemeContrast) var colorSchemeContrast
-    @Environment(\.sizeCategory) var sizeCategory
-    @Environment(\.userId) var userId
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.userId) private var userId
 
-    var model: Model
-    var contextMenuModel: EventContextMenuModel
-    var connectedEdges: ConnectedEdges
-    var isEdited = false
+    let model: Model
+    let contextMenuModel: EventContextMenuModel
+    let connectedEdges: ConnectedEdges
+    var isEdited: Bool = false
 
-    var isMe: Bool {
+    private var isMe: Bool {
         model.sender == userId
     }
 
@@ -31,7 +31,7 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         }
     }
 
-    var backgroundColor: Color {
+    private var backgroundColor: Color {
         if isMe {
             return .accentColor
         } else {
@@ -39,7 +39,7 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         }
     }
 
-    var gradient: LinearGradient {
+    private var gradient: LinearGradient {
         let color: Color = backgroundColor
         let colors: [Color]
         if colorScheme == .dark {
@@ -54,7 +54,7 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         )
     }
 
-    var background: some View {
+    private var background: some View {
         let largeRadius: CGFloat = 15.0 * sizeCategory.scalingFactor
         let smallRadius: CGFloat = 5.0 * sizeCategory.scalingFactor
 
@@ -70,13 +70,13 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         .scaleEffect(x: isMe ? -1.0 : 1.0, y: 1.0, anchor: .center)
     }
 
-    var timestampView: some View {
+    private var timestampView: some View {
         Text(model.timestamp)
             .font(.caption)
             .foregroundColor(.secondary)
     }
 
-    var markdownView: some View {
+    private var markdownView: some View {
         MarkdownText(
             markdown: model.text,
             textColor: .messageTextColor(for: colorScheme, isOutgoing: isMe),
@@ -100,7 +100,7 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         }
     }
 
-    var editBadgeView: some View {
+    private var editBadgeView: some View {
         let foregroundColor = Color.backgroundColor(for: colorScheme)
         return BadgeView(
             image: Image(Asset.Badge.edited.name),

--- a/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
@@ -4,37 +4,37 @@ import MatrixSDK
 import NioKit
 
 struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol {
-    @Environment(\.colorScheme) var colorScheme
-    @Environment(\.colorSchemeContrast) var colorSchemeContrast
-    @Environment(\.sizeCategory) var sizeCategory
-    @Environment(\.userId) var userId
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.userId) private var userId
 
-    var model: Model
-    var contextMenuModel: EventContextMenuModel
-    var connectedEdges: ConnectedEdges
+    let model: Model
+    let contextMenuModel: EventContextMenuModel
+    let connectedEdges: ConnectedEdges
     var isEdited = false
 
-    var isMe: Bool {
+    private var isMe: Bool {
         model.sender == userId
     }
 
-    var timestampView: some View {
+    private var timestampView: some View {
         Text(model.timestamp)
             .font(.caption)
             .foregroundColor(.secondary)
             .padding(10)
     }
 
-    var emojiView: some View {
+    private var emojiView: some View {
         Text(model.text)
         .font(.system(size: 60 * sizeCategory.scalingFactor))
     }
 
-    var contentView: some View {
+    private var contentView: some View {
         emojiView
     }
 
-    var conditionalBadgedContentView: some View {
+    private var conditionalBadgedContentView: some View {
         ZStack(alignment: isMe ? .bottomLeading : .bottomTrailing) {
             contentView
             if isEdited {
@@ -55,7 +55,7 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
         }
     }
 
-    var gradient: LinearGradient {
+    private var gradient: LinearGradient {
         let color: Color = .borderedMessageBackground
         let colors: [Color]
         if colorScheme == .dark {
@@ -70,14 +70,14 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
         )
     }
 
-    var backgroundColor: Color {
+    private var backgroundColor: Color {
         guard model.sender == userId else {
             return .borderedMessageBackground
         }
         return .accentColor
     }
 
-    var editBadgeView: some View {
+    private var editBadgeView: some View {
         let foregroundColor = Color.backgroundColor(for: colorScheme)
         return BadgeView(image: Image(Asset.Badge.edited.name),
                          foregroundColor: foregroundColor,
@@ -85,7 +85,7 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
             .frame(width: 20.0, height: 20.0)
     }
 
-    var bodyView: some View {
+    private var bodyView: some View {
         VStack(alignment: isMe ? .trailing : .leading, spacing: 0) {
             if isMe {
                 HStack {

--- a/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderlessMessageView.swift
@@ -44,14 +44,10 @@ struct BorderlessMessageView<Model>: View where Model: MessageViewModelProtocol 
         }
     }
 
-    var senderView: some View {
+    @ViewBuilder private var senderView: some View {
         if model.showSender && !isMe && (connectedEdges == .bottomEdge || connectedEdges.isEmpty) {
-            return AnyView(
-                Text(model.sender)
-                    .font(.caption)
-            )
-        } else {
-            return AnyView(EmptyView())
+            Text(model.sender)
+                .font(.caption)
         }
     }
 

--- a/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
@@ -77,14 +77,10 @@ struct MediaEventView: View {
         .font(.caption)
     }
 
-    var senderView: some View {
+    @ViewBuilder private var senderView: some View {
         if model.showSender && !isMe {
-            return AnyView(
                 Text(model.sender)
                     .font(.caption)
-            )
-        } else {
-            return AnyView(EmptyView())
         }
     }
 

--- a/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MediaEventView.swift
@@ -4,16 +4,16 @@ import SDWebImageSwiftUI
 import BlurHash
 
 struct MediaEventView: View {
-    @Environment(\.userId) var userId
-    @Environment(\.homeserver) var homeserver
+    @Environment(\.userId) private var userId
+    @Environment(\.homeserver) private var homeserver
 
     struct ViewModel {
-        let mediaURLs: [MXURL]
-        let sender: String
-        let showSender: Bool
-        let timestamp: String
-        var size: CGSize?
-        var blurhash: String?
+        fileprivate let mediaURLs: [MXURL]
+        fileprivate let sender: String
+        fileprivate let showSender: Bool
+        fileprivate let timestamp: String
+        fileprivate var size: CGSize?
+        fileprivate var blurhash: String?
 
         init(mediaURLs: [String],
              sender: String,
@@ -68,11 +68,11 @@ struct MediaEventView: View {
         }
     }
 
-    var isMe: Bool {
+    private var isMe: Bool {
         model.sender == userId
     }
 
-    var timestampView: some View {
+    private var timestampView: some View {
         Text(model.timestamp)
         .font(.caption)
     }

--- a/Nio/Conversations/Event Views/MessageView/MessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageView.swift
@@ -26,15 +26,15 @@ struct MessageView<Model>: View where Model: MessageViewModelProtocol {
                 isEdited: self.isEdited
             )
             if isMe {
-                return AnyView(HStack {
+                HStack {
                     Spacer()
                     messageView
-                })
+                }
             } else {
-                return AnyView(HStack {
+                HStack {
                     messageView
                     Spacer()
-                })
+                }
             }
         } else {
             let messageView = BorderedMessageView(
@@ -44,15 +44,15 @@ struct MessageView<Model>: View where Model: MessageViewModelProtocol {
                 isEdited: self.isEdited
             )
             if isMe {
-                return AnyView(HStack {
+                HStack {
                     Spacer()
                     messageView
-                })
+                }
             } else {
-                return AnyView(HStack {
+                HStack {
                     messageView
                     Spacer()
-                })
+                }
             }
         }
     }

--- a/Nio/Conversations/Event Views/MessageView/MessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/MessageView.swift
@@ -4,13 +4,13 @@ import MatrixSDK
 import NioKit
 
 struct MessageView<Model>: View where Model: MessageViewModelProtocol {
-    @Environment(\.colorScheme) var colorScheme
-    @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
-    @Environment(\.userId) var userId
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.sizeCategory) private var sizeCategory: ContentSizeCategory
+    @Environment(\.userId) private var userId
 
     @Binding var model: Model
-    var contextMenuModel: EventContextMenuModel
-    var connectedEdges: ConnectedEdges
+    let contextMenuModel: EventContextMenuModel
+    let connectedEdges: ConnectedEdges
     var isEdited = false
 
     private var isMe: Bool {

--- a/Nio/Conversations/Event Views/MessageView/Reactions/GroupedReactionsView.swift
+++ b/Nio/Conversations/Event Views/MessageView/Reactions/GroupedReactionsView.swift
@@ -54,14 +54,11 @@ struct GroupedReactionsView: View {
         return .borderedMessageBackground
     }
 
+    @ViewBuilder
     fileprivate func backgroundOverlay(for group: ReactionGroup) -> some View {
         if group.containsReaction(from: userId) {
-            return AnyView(
-                RoundedRectangle(cornerRadius: 30)
-                    .stroke(self.backgroundColor(for: group), lineWidth: 2)
-            )
-        } else {
-            return AnyView(EmptyView())
+            RoundedRectangle(cornerRadius: 30)
+                .stroke(self.backgroundColor(for: group), lineWidth: 2)
         }
     }
 

--- a/Nio/Conversations/Event Views/MessageView/Reactions/GroupedReactionsView.swift
+++ b/Nio/Conversations/Event Views/MessageView/Reactions/GroupedReactionsView.swift
@@ -7,9 +7,9 @@ struct GroupedReactionsView: View {
     @Environment(\.userId) var userId
 
     struct ViewModel {
-        var reactions: [Reaction]
+        let reactions: [Reaction]
 
-        init(reactions: [Reaction]) {
+        fileprivate init(reactions: [Reaction]) {
             self.reactions = reactions
         }
 

--- a/Nio/Conversations/Event Views/MessageView/Reactions/ReactionGroupView.swift
+++ b/Nio/Conversations/Event Views/MessageView/Reactions/ReactionGroupView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct ReactionGroupView: View {
-    let text: String
-    let count: Int
+    private let text: String
+    private let count: Int
 
-    let backgroundColor: Color
+    private let backgroundColor: Color
 
     init(text: String, count: Int, backgroundColor: Color) {
         assert(count > 0, "Expected non-zero positive integer")

--- a/Nio/Conversations/Event Views/MessageView/Reactions/ReactionsListItemView.swift
+++ b/Nio/Conversations/Event Views/MessageView/Reactions/ReactionsListItemView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 import NioKit
 
 struct ReactionsListItemView: View {
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @Environment(\.colorSchemeContrast) var colorSchemeContrast: ColorSchemeContrast
-    @Environment(\.userId) var userId
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast: ColorSchemeContrast
+    @Environment(\.userId) private var userId
 
     let reaction: Reaction
 

--- a/Nio/Conversations/Event Views/RedactionEventView.swift
+++ b/Nio/Conversations/Event Views/RedactionEventView.swift
@@ -7,9 +7,9 @@ struct RedactionEventView: View {
         let reason: String?
     }
 
-    var model: ViewModel
+    let model: ViewModel
 
-    var redactionText: String {
+    private var redactionText: String {
         if model.sender == model.redactor {
             return "🗑 \(L10n.Event.Redaction.redactSelf(model.redactor))"
         }

--- a/Nio/Conversations/Event Views/RoomMemberEventView.swift
+++ b/Nio/Conversations/Event Views/RoomMemberEventView.swift
@@ -3,7 +3,7 @@ import class MatrixSDK.MXEvent
 
 struct RoomMemberEventView: View {
     struct ViewModel {
-        let sender: String
+        private let sender: String
 
         struct User {
             let displayName: String
@@ -12,8 +12,8 @@ struct RoomMemberEventView: View {
             let reason: String?
         }
 
-        let current: User
-        let previous: User?
+        fileprivate let current: User
+        private let previous: User?
 
         var hasUserInfoDifference: Bool {
             guard let previous = previous else { return false }

--- a/Nio/Conversations/Event Views/RoomNameEventView.swift
+++ b/Nio/Conversations/Event Views/RoomNameEventView.swift
@@ -3,9 +3,9 @@ import class MatrixSDK.MXEvent
 
 struct RoomNameEventView: View {
     struct ViewModel {
-        let sender: String
-        let newName: String
-        let oldName: String?
+        fileprivate let sender: String
+        fileprivate let newName: String
+        fileprivate let oldName: String?
 
         init(event: MXEvent) {
             self.sender = event.sender ?? ""
@@ -20,7 +20,7 @@ struct RoomNameEventView: View {
         }
     }
 
-    var model: ViewModel
+    let model: ViewModel
 
     var body: some View {
         if let oldName = model.oldName {

--- a/Nio/Conversations/Event Views/RoomPowerLevelsEventView.swift
+++ b/Nio/Conversations/Event Views/RoomPowerLevelsEventView.swift
@@ -3,7 +3,7 @@ import class MatrixSDK.MXEvent
 
 struct RoomPowerLevelsEventView: View {
     struct ViewModel {
-        let sender: String
+        fileprivate let sender: String
 
         struct LevelChange: Identifiable {
             let name: String
@@ -21,15 +21,15 @@ struct RoomPowerLevelsEventView: View {
                 }
             }
 
-            var oldLevelName: String {
+            fileprivate var oldLevelName: String {
                 old.map { levelName($0) } ?? L10n.RoomPowerLevel.default
             }
 
-            var newLevelName: String {
+            fileprivate var newLevelName: String {
                 levelName(new)
             }
         }
-        let changes: [LevelChange]
+        private let changes: [LevelChange]
 
         init(sender: String,
              changes: [LevelChange]) {
@@ -72,7 +72,7 @@ struct RoomPowerLevelsEventView: View {
         }
     }
 
-    var model: ViewModel
+    let model: ViewModel
 
     var body: some View {
         GenericEventView(text: model.combined)

--- a/Nio/Conversations/MessageComposerView.swift
+++ b/Nio/Conversations/MessageComposerView.swift
@@ -12,9 +12,9 @@ struct ExDivider: View {
 }
 
 struct MessageComposerView: View {
-    @Environment (\.colorScheme) var colorScheme
-    @Environment(\.colorSchemeContrast) var colorSchemeContrast
-    @Environment(\.sizeCategory) var sizeCategory
+    @Environment (\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+    @Environment(\.sizeCategory) private var sizeCategory
 
     @Binding var showAttachmentPicker: Bool
 
@@ -26,14 +26,14 @@ struct MessageComposerView: View {
 
     var highlightMessage: String?
 
-    var onCancel: () -> Void
-    var onCommit: () -> Void
+    let onCancel: () -> Void
+    let onCommit: () -> Void
 
-    var backgroundColor: Color {
+    private var backgroundColor: Color {
         colorScheme == .light ? Color(#colorLiteral(red: 0.9332506061, green: 0.937307477, blue: 0.9410644174, alpha: 1)) : Color(#colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1))
     }
 
-    var gradient: LinearGradient {
+    private var gradient: LinearGradient {
         let color: Color = backgroundColor
         let colors: [Color]
         if colorScheme == .dark {
@@ -48,7 +48,7 @@ struct MessageComposerView: View {
         )
     }
 
-    var background: some View {
+    private var background: some View {
         RoundedRectangle(cornerRadius: 10.0 * sizeCategory.scalingFactor)
             .fill(gradient).opacity(0.9)
     }
@@ -90,7 +90,7 @@ struct MessageComposerView: View {
         }
     }
 
-    var attachmentPickerButton: some View {
+    private var attachmentPickerButton: some View {
         Button(action: {
             self.showAttachmentPicker.toggle()
         }, label: {
@@ -116,7 +116,7 @@ struct MessageComposerView: View {
         .frame(height: self.messageEditorHeight)
     }
 
-    var sendButton: some View {
+    private var sendButton: some View {
         Button(action: {
             self.onCommit()
         }, label: {

--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -35,15 +35,15 @@ struct RecentRoomsView: View {
 
     var rooms: [NIORoom]
 
-    var joinedRooms: [NIORoom] {
+    private var joinedRooms: [NIORoom] {
         rooms.filter {$0.room.summary.membership == .join}
     }
 
-    var invitedRooms: [NIORoom] {
+    private var invitedRooms: [NIORoom] {
         rooms.filter {$0.room.summary.membership == .invite}
     }
 
-    var settingsButton: some View {
+    private var settingsButton: some View {
         Button(action: {
             self.selectedNavigationItem = .settings
         }, label: {
@@ -54,7 +54,7 @@ struct RecentRoomsView: View {
         })
     }
 
-    var newConversationButton: some View {
+    private var newConversationButton: some View {
         Button(action: {
             self.selectedNavigationItem = .newConversation
         }, label: {
@@ -117,7 +117,7 @@ struct RoomsListSection: View {
         return self.rooms[leaveId]
     }
 
-    var sectionContent: some View {
+    private var sectionContent: some View {
         ForEach(rooms) { room in
             NavigationLink(destination: RoomContainerView(room: room), tag: room.id, selection: $selectedRoomId) {
                 RoomListItemContainerView(room: room)
@@ -127,7 +127,7 @@ struct RoomsListSection: View {
     }
 
     @ViewBuilder
-    var section: some View {
+    private var section: some View {
         if let sectionHeader = sectionHeader {
             Section(header: Text(sectionHeader)) {
                 sectionContent
@@ -150,21 +150,19 @@ struct RoomsListSection: View {
                         ?? "")),
                 primaryButton: .destructive(
                     Text(L10n.Room.Remove.action),
-                    action: {
-                        self.leaveRoom()
-                }),
+                    action: self.leaveRoom),
             secondaryButton: .cancel())
         }
     }
 
-    func setLeaveIndex(at offsets: IndexSet) {
+    private func setLeaveIndex(at offsets: IndexSet) {
         self.showConfirm = true
         for offset in offsets {
             self.leaveId = offset
         }
     }
 
-    func leaveRoom() {
+    private func leaveRoom() {
         guard let leaveId = self.leaveId, rooms.count > leaveId else { return }
         guard let mxRoom = self.roomToLeave?.room else { return }
         mxRoom.mxSession?.leaveRoom(mxRoom.roomId) { _ in }

--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -185,13 +185,9 @@ private struct NavigationSheet: View {
     var body: some View {
         switch selectedItem {
         case .settings:
-            return AnyView(
-                SettingsContainerView()
-            )
+            SettingsContainerView()
         case .newConversation:
-            return AnyView(
-                NewConversationContainerView(createdRoomId: $selectedRoomId)
-            )
+            NewConversationContainerView(createdRoomId: $selectedRoomId)
         }
     }
 }

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -5,27 +5,27 @@ import SDWebImageSwiftUI
 import NioKit
 
 struct RoomListItemContainerView: View {
-    @EnvironmentObject var store: AccountStore
+    @EnvironmentObject private var store: AccountStore
 
-    var room: NIORoom
-
+    let room: NIORoom
+  
+    private var roomAvatarURL: URL? {
+        guard let client = store.client,
+              let homeserver = URL(string: client.homeserver),
+              let avatar = room.summary.avatar else { return nil }
+        return MXURL(mxContentURI: avatar)?.contentURL(on: homeserver)
+    }
+  
     var body: some View {
         let roomName = room.summary.displayname ?? ""
         let lastMessage = room.lastMessage
         let lastActivity = Formatter.string(forRelativeDate: room.summary.lastMessageDate)
 
-        var accessibilityLabel = ""
+        let accessibilityLabel : String
         if room.isDirect {
             accessibilityLabel = L10n.RecentRooms.AccessibilityLabel.dm(roomName, lastActivity, lastMessage)
         } else {
             accessibilityLabel = L10n.RecentRooms.AccessibilityLabel.room(roomName, lastActivity, lastMessage)
-        }
-
-        var roomAvatarURL: URL?
-        if let client = store.client,
-            let homeserver = URL(string: client.homeserver),
-            let avatar = room.summary.avatar {
-                roomAvatarURL = MXURL(mxContentURI: avatar)?.contentURL(on: homeserver)
         }
 
         return RoomListItemView(title: room.summary.displayname ?? "",
@@ -33,21 +33,21 @@ struct RoomListItemContainerView: View {
                                 rightDetail: lastActivity,
                                 badge: room.summary.localUnreadEventCount,
                                 roomAvatarURL: roomAvatarURL)
-        .accessibility(label: Text(accessibilityLabel))
+               .accessibility(label: Text(verbatim: accessibilityLabel))
     }
 }
 
 struct RoomListItemView: View {
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-    @Environment(\.colorSchemeContrast) var colorSchemeContrast: ColorSchemeContrast
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast: ColorSchemeContrast
 
-    var title: String
-    var subtitle: String
-    var rightDetail: String
-    var badge: UInt
-    var roomAvatarURL: URL?
+    fileprivate let title: String
+    fileprivate let subtitle: String
+    fileprivate let rightDetail: String
+    fileprivate let badge: UInt
+    fileprivate let roomAvatarURL: URL?
 
-    var gradient: LinearGradient {
+    private var gradient: LinearGradient {
         let color: Color = .white
         let colors = [color.opacity(0.3), color.opacity(0.0)]
         return LinearGradient(
@@ -57,9 +57,9 @@ struct RoomListItemView: View {
         )
     }
 
-    var prefixAvatar: some View {
+    private var prefixAvatar: some View {
         GeometryReader { geometry in
-            Text(title.prefix(2).uppercased())
+            Text(verbatim: title.prefix(2).uppercased())
                 .multilineTextAlignment(.center)
                 .font(.system(.headline, design: .rounded))
                 .lineLimit(1)
@@ -73,7 +73,7 @@ struct RoomListItemView: View {
         .accessibility(addTraits: .isImage)
     }
 
-    var topView: some View {
+    private var topView: some View {
         HStack(alignment: .top) {
             titleView
             Spacer()
@@ -82,22 +82,22 @@ struct RoomListItemView: View {
         .padding(.bottom, 5)
     }
 
-    var titleView: some View {
-        Text(title)
+    private var titleView: some View {
+        Text(verbatim: title)
             .font(.headline)
             .lineLimit(1)
             .allowsTightening(true)
     }
 
-    var timeAgoView: some View {
-        Text(rightDetail)
+    private var timeAgoView: some View {
+        Text(verbatim: rightDetail)
             .font(.caption)
             .lineLimit(1)
             .allowsTightening(true)
             .foregroundColor(.secondary)
     }
 
-    var bottomView: some View {
+    private var bottomView: some View {
         HStack {
             subtitleView
             if badge != 0 {
@@ -107,8 +107,8 @@ struct RoomListItemView: View {
         }
     }
 
-    var subtitleView: some View {
-        Text(subtitle.isEmpty ? " " : subtitle)     // Replace empty string with space to maintain height
+    private var subtitleView: some View {
+        Text(verbatim: subtitle.isEmpty ? " " : subtitle)     // Replace empty string with space to maintain height
             .multilineTextAlignment(.leading)
             .font(.subheadline)
             .lineLimit(1)
@@ -118,8 +118,8 @@ struct RoomListItemView: View {
             .padding(.vertical, badgeTextVerticalPadding)
     }
 
-    var badgeView: some View {
-        Text(String(self.badge))
+    private var badgeView: some View {
+        Text(verbatim: String(self.badge))
             .font(.caption)
             .lineLimit(1)
             .allowsTightening(true)
@@ -139,9 +139,9 @@ struct RoomListItemView: View {
             )
     }
 
-    var badgeTextVerticalPadding: CGFloat { 3 * sizeCategory.scalingFactor }
+    private var badgeTextVerticalPadding: CGFloat { 3 * sizeCategory.scalingFactor }
 
-    var avatarView: some View {
+    private var avatarView: some View {
         Circle()
             .foregroundColor(.clear)
             .aspectRatio(1, contentMode: .fill)
@@ -159,7 +159,7 @@ struct RoomListItemView: View {
         }
     }
 
-    @Environment(\.sizeCategory) var sizeCategory
+    @Environment(\.sizeCategory) private var sizeCategory
 
     var body: some View {
         HStack(alignment: .center) {
@@ -169,7 +169,7 @@ struct RoomListItemView: View {
                 bottomView
             }.layoutPriority(1)
         }
-        .padding([.vertical], 5 * sizeCategory.scalingFactor)
+        .padding(.vertical, 5 * sizeCategory.scalingFactor)
     }
 }
 

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -8,20 +8,20 @@ struct RoomListItemContainerView: View {
     @EnvironmentObject private var store: AccountStore
 
     let room: NIORoom
-  
+
     private var roomAvatarURL: URL? {
         guard let client = store.client,
               let homeserver = URL(string: client.homeserver),
               let avatar = room.summary.avatar else { return nil }
         return MXURL(mxContentURI: avatar)?.contentURL(on: homeserver)
     }
-  
+
     var body: some View {
         let roomName = room.summary.displayname ?? ""
         let lastMessage = room.lastMessage
         let lastActivity = Formatter.string(forRelativeDate: room.summary.lastMessageDate)
 
-        let accessibilityLabel : String
+        let accessibilityLabel: String
         if room.isDirect {
             accessibilityLabel = L10n.RecentRooms.AccessibilityLabel.dm(roomName, lastActivity, lastMessage)
         } else {

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -148,18 +148,14 @@ struct RoomListItemView: View {
             .overlay(image.mask(Circle()))
     }
 
-    var image: some View {
+    @ViewBuilder private var image: some View {
         if let avatarURL = roomAvatarURL {
-            return AnyView(
-                WebImage(url: avatarURL)
-                    .resizable()
-                    .placeholder { prefixAvatar }
-                    .aspectRatio(contentMode: .fill)
-            )
+            WebImage(url: avatarURL)
+                .resizable()
+                .placeholder { prefixAvatar }
+                .aspectRatio(contentMode: .fill)
         } else {
-            return AnyView(
-                prefixAvatar
-            )
+            prefixAvatar
         }
     }
 

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -7,10 +7,10 @@ import NioKit
 struct RoomContainerView: View {
     @ObservedObject var room: NIORoom
 
-    @State var showAttachmentPicker = false
-    @State var showImagePicker = false
-    @State var eventToReactTo: String?
-    @State var showJoinAlert = false
+    @State private var showAttachmentPicker = false
+    @State private var showImagePicker = false
+    @State private var eventToReactTo: String?
+    @State private var showJoinAlert = false
 
     var body: some View {
         RoomView(
@@ -87,9 +87,9 @@ struct RoomContainerView: View {
 }
 
 struct RoomView: View {
-    @Environment(\.userId) var userId
-    @EnvironmentObject var room: NIORoom
-    @EnvironmentObject var store: AccountStore
+    @Environment(\.userId) private var userId
+    @EnvironmentObject private var room: NIORoom
+    @EnvironmentObject private var store: AccountStore
 
     var events: EventCollection
     var isDirect: Bool

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -91,15 +91,15 @@ struct RoomView: View {
     @EnvironmentObject private var room: NIORoom
     @EnvironmentObject private var store: AccountStore
 
-    var events: EventCollection
-    var isDirect: Bool
+    let events: EventCollection
+    let isDirect: Bool
 
     @Binding var showAttachmentPicker: Bool
-    var onCommit: (String) -> Void
+    let onCommit: (String) -> Void
 
-    var onReact: (String) -> Void
-    var onRedact: (String, String?) -> Void
-    var onEdit: (String, String) -> Void
+    let onReact: (String) -> Void
+    let onRedact: (String, String?) -> Void
+    let onEdit: (String, String) -> Void
 
     @State private var editEventId: String?
     @State private var eventToRedact: String?

--- a/Nio/Conversations/TypingIndicatorView.swift
+++ b/Nio/Conversations/TypingIndicatorView.swift
@@ -4,7 +4,7 @@ import NioKit
 
 struct TypingIndicatorContainerView: View {
     @EnvironmentObject private var room: NIORoom
-    @Environment(\.userId) var userId
+    @Environment(\.userId) private var userId
 
     private var typingUsers: [String] {
         room.room.typingUsers?.filter { $0 != userId} ?? []
@@ -17,9 +17,9 @@ struct TypingIndicatorContainerView: View {
 
 struct TypingIndicatorView: View {
     @Environment(\.colorScheme) var colorScheme: ColorScheme
-    var typingUsers: [String]
+    let typingUsers: [String]
 
-    var text: String {
+    private var text: String {
         switch typingUsers.count {
         case 1:
             return L10n.TypingIndicator.single(typingUsers.first!)
@@ -30,7 +30,7 @@ struct TypingIndicatorView: View {
         }
     }
 
-    var backgroundColor: Color {
+    private var backgroundColor: Color {
         switch self.colorScheme {
         case .dark:
             return Color(#colorLiteral(red: 0.1221848231, green: 0.1316168257, blue: 0.1457917546, alpha: 1))

--- a/Nio/NewConversation/NewConversationView.swift
+++ b/Nio/NewConversation/NewConversationView.swift
@@ -4,7 +4,7 @@ import MatrixSDK
 import NioKit
 
 struct NewConversationContainerView: View {
-    @EnvironmentObject var store: AccountStore
+    @EnvironmentObject private var store: AccountStore
     @Binding var createdRoomId: ObjectIdentifier?
 
     var body: some View {
@@ -13,9 +13,9 @@ struct NewConversationContainerView: View {
 }
 
 struct NewConversationView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.presentationMode) private var presentationMode
 
-    var store: AccountStore?
+    let store: AccountStore?
 
     @State private var users = [""]
     @State private var editMode = EditMode.inactive
@@ -26,7 +26,7 @@ struct NewConversationView: View {
     @Binding var createdRoomId: ObjectIdentifier?
     @State private var errorMessage: String?
 
-    var usersFooter: some View {
+    private var usersFooter: some View {
         Text("\(L10n.NewConversation.forExample) \(store?.session?.myUserId ?? "@username:server.org")")
     }
 
@@ -107,13 +107,13 @@ struct NewConversationView: View {
         }
     }
 
-    func addUser() {
+    private func addUser() {
         withAnimation {
             users.append("")
         }
     }
 
-    func createRoom() {
+    private func createRoom() {
         isWaiting = true
 
         let parameters = MXRoomCreationParameters()

--- a/Nio/NioApp.swift
+++ b/Nio/NioApp.swift
@@ -3,9 +3,9 @@ import NioKit
 
 @main
 struct NioApp: App {
-    @StateObject var accountStore = AccountStore()
+    @StateObject private var accountStore = AccountStore()
 
-    @AppStorage("accentColor") var accentColor: Color = .purple
+    @AppStorage("accentColor") private var accentColor: Color = .purple
 
     var body: some Scene {
         WindowGroup {

--- a/Nio/RootView.swift
+++ b/Nio/RootView.swift
@@ -3,15 +3,23 @@ import SwiftUI
 import NioKit
 
 struct RootView: View {
-    @EnvironmentObject var store: AccountStore
+    @EnvironmentObject private var store: AccountStore
+  
+    private var homeserverURL: URL {
+        // Can this ever be nil? And if so, what happens with the default fallback?
+        assert(store.client != nil)
+        let configuredURL = store.client?.homeserver.flatMap(URL.init)
+        assert(configuredURL != nil)
+        return configuredURL ?? HomeserverKey.defaultValue
+    }
 
     var body: some View {
         switch store.loginState {
         case .loggedIn(let userId):
             RecentRoomsContainerView()
                 .environment(\.userId, userId)
-                // Can this ever be nil? And if so, what happens with the default fallback?
-                .environment(\.homeserver, (store.client?.homeserver.flatMap(URL.init)) ?? HomeserverKey.defaultValue)
+                .environment(\.homeserver, homeserverURL)
+          
         case .loggedOut:
             LoginContainerView()
 
@@ -23,11 +31,10 @@ struct RootView: View {
                 Spacer()
                 Text(error.localizedDescription)
                 Spacer()
-                Button(action: {
-                    self.store.loginState = .loggedOut
-                }, label: {
+                Button(action: { self.store.loginState = .loggedOut }) {
                     Text(L10n.Login.failureBackToLogin)
-                }).padding()
+                }
+                .padding()
             }
         }
     }

--- a/Nio/RootView.swift
+++ b/Nio/RootView.swift
@@ -4,7 +4,7 @@ import NioKit
 
 struct RootView: View {
     @EnvironmentObject private var store: AccountStore
-  
+
     private var homeserverURL: URL {
         // Can this ever be nil? And if so, what happens with the default fallback?
         assert(store.client != nil)
@@ -19,7 +19,7 @@ struct RootView: View {
             RecentRoomsContainerView()
                 .environment(\.userId, userId)
                 .environment(\.homeserver, homeserverURL)
-          
+
         case .loggedOut:
             LoginContainerView()
 

--- a/Nio/RootView.swift
+++ b/Nio/RootView.swift
@@ -8,33 +8,27 @@ struct RootView: View {
     var body: some View {
         switch store.loginState {
         case .loggedIn(let userId):
-            return AnyView(
-                RecentRoomsContainerView()
-                    .environment(\.userId, userId)
-                    // Can this ever be nil? And if so, what happens with the default fallback?
-                    .environment(\.homeserver, (store.client?.homeserver.flatMap(URL.init)) ?? HomeserverKey.defaultValue)
-            )
+            RecentRoomsContainerView()
+                .environment(\.userId, userId)
+                // Can this ever be nil? And if so, what happens with the default fallback?
+                .environment(\.homeserver, (store.client?.homeserver.flatMap(URL.init)) ?? HomeserverKey.defaultValue)
         case .loggedOut:
-            return AnyView(
-                LoginContainerView()
-            )
+            LoginContainerView()
+
         case .authenticating:
-            return AnyView(
-                LoadingView()
-            )
+            LoadingView()
+
         case .failure(let error):
-            return AnyView(
-                VStack {
-                    Spacer()
-                    Text(error.localizedDescription)
-                    Spacer()
-                    Button(action: {
-                        self.store.loginState = .loggedOut
-                    }, label: {
-                        Text(L10n.Login.failureBackToLogin)
-                    }).padding()
-                }
-            )
+            VStack {
+                Spacer()
+                Text(error.localizedDescription)
+                Spacer()
+                Button(action: {
+                    self.store.loginState = .loggedOut
+                }, label: {
+                    Text(L10n.Login.failureBackToLogin)
+                }).padding()
+            }
         }
     }
 }

--- a/Nio/Settings/SettingsView.swift
+++ b/Nio/Settings/SettingsView.swift
@@ -11,11 +11,11 @@ struct SettingsContainerView: View {
 }
 
 struct SettingsView: View {
-    @AppStorage("accentColor") var accentColor: Color = .purple
+    @AppStorage("accentColor") private var accentColor: Color = .purple
     @StateObject private var appIconTitle = AppIconTitle()
-    var logoutAction: () -> Void
+    let logoutAction: () -> Void
 
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.presentationMode) private var presentationMode
 
     var body: some View {
         NavigationView {

--- a/Nio/Shared Views/MarkdownText.swift
+++ b/Nio/Shared Views/MarkdownText.swift
@@ -3,8 +3,8 @@ import SwiftUI
 import CommonMarkAttributedString
 
 struct MarkdownText: View {
-    let markdown: String
-    let textColor: UIColor
+    private let markdown: String
+    private let textColor: UIColor
 
     @State private var contentSizeThatFits: CGSize = .zero
 

--- a/Nio/Shared Views/ReverseList.swift
+++ b/Nio/Shared Views/ReverseList.swift
@@ -10,9 +10,9 @@ struct IsVisibleKey: PreferenceKey {
 }
 
 struct ReverseList<Element, Content>: View where Element: Identifiable, Content: View {
-    var items: [Element]
-    var reverseItemOrder: Bool
-    var viewForItem: (Element) -> Content
+    private let items: [Element]
+    private let reverseItemOrder: Bool
+    private let viewForItem: (Element) -> Content
 
     @Binding var hasReachedTop: Bool
 

--- a/Nio/Shared Views/UITextViewWrapper.swift
+++ b/Nio/Shared Views/UITextViewWrapper.swift
@@ -42,11 +42,11 @@ struct UITextViewWrapper: UIViewRepresentable {
     }
 
     @Environment(\.textAttributes)
-    var envTextAttributes: TextAttributes
+    private var envTextAttributes: TextAttributes
 
-    @Binding var attributedText: NSAttributedString
-    @Binding var isEditing: Bool
-    @Binding var sizeThatFits: CGSize
+    @Binding private var attributedText: NSAttributedString
+    @Binding private var isEditing: Bool
+    @Binding private var sizeThatFits: CGSize
 
     private let maxSize: CGSize
 


### PR DESCRIPTION
One should avoid `AnyView` as much as possible, there is rarely any reason to use it (anymore). Most changes are trivial, but the `EventContainerView` had to be reorganised a little (it is now "functional" ;-)).

Also fixed the visibility as well as the mutability of a ton of properties. (a few have been left `var` to make use of the autogenerated `init`, maybe those should be fixed too).

