### PR TITLE
Escape `<` in messages with `&lt;`

### DIFF
--- a/Nio/Shared Views/MarkdownText.swift
+++ b/Nio/Shared Views/MarkdownText.swift
@@ -38,6 +38,7 @@ struct MarkdownText: View {
 
     internal var attributedText: NSAttributedString {
         let markdownString = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+          .replacingOccurrences(of: "<", with: "&lt;")
         let attributedString = try? NSAttributedString(
             commonmark: markdownString,
             attributes: attributes


### PR DESCRIPTION
This is to workaround https://github.com/niochat/nio/issues/260, but it also seems the correct thing to do. Matrix message content is not Markdown and tags within should not be parsed as HTML.

(That the WebKit parsing crashes as a sideeffect is distinct. But goes away w/ this ...)