### PR TITLE
Don't localize twize

### DIFF
--- a/Nio/Authentication/LoadingView.swift
+++ b/Nio/Authentication/LoadingView.swift
@@ -38,7 +38,7 @@ struct LoadingView: View {
             Button(action: {
                 self.store.logout()
             }, label: {
-                Text(L10n.Loading.cancel).font(.callout)
+                Text(verbatim: L10n.Loading.cancel).font(.callout)
             }).padding()
         }
     }

--- a/Nio/Authentication/LoginView.swift
+++ b/Nio/Authentication/LoginView.swift
@@ -97,7 +97,7 @@ struct LoginView: View {
             Button(action: {
                 self.onLogin()
             }, label: {
-                Text(L10n.Login.signIn)
+                Text(verbatim: L10n.Login.signIn)
                     .font(.system(size: 18))
                     .bold()
             })
@@ -107,7 +107,7 @@ struct LoginView: View {
             Button(action: {
                 self.showingRegisterView.toggle()
             }, label: {
-                Text(L10n.Login.openRegistrationPrompt).font(.footnote)
+                Text(verbatim: L10n.Login.openRegistrationPrompt).font(.footnote)
             })
         }
     }
@@ -118,10 +118,10 @@ struct LoginTitleView: View {
         let nio = Text("Nio").foregroundColor(.accentColor)
 
         return VStack {
-            (Text("👋") + Text(L10n.Login.welcomeHeader) + nio + Text("!"))
+            (Text("👋") + Text(verbatim: L10n.Login.welcomeHeader) + nio + Text("!"))
                 .font(.title)
                 .bold()
-            Text(L10n.Login.welcomeMessage)
+            Text(verbatim: L10n.Login.welcomeMessage)
         }
     }
 }
@@ -142,7 +142,7 @@ struct LoginForm: View {
             FormTextField(title: L10n.Login.Form.password, text: $password, isSecure: true)
 
             FormTextField(title: L10n.Login.Form.homeserver, text: $homeserver, keyboardType: .URL)
-            Text(L10n.Login.Form.homeserverOptionalExplanation)
+            Text(verbatim: L10n.Login.Form.homeserverOptionalExplanation)
                 .font(.caption)
                 .foregroundColor(.gray)
         }

--- a/Nio/Conversations/ContextMenu/EventContextMenu.swift
+++ b/Nio/Conversations/ContextMenu/EventContextMenu.swift
@@ -80,7 +80,7 @@ struct EventContextMenu: View {
         Group {
             if model.canReact {
                 Button(action: onReact, label: {
-                    Text(L10n.Event.ContextMenu.addReaction)
+                    Text(verbatim: L10n.Event.ContextMenu.addReaction)
                     Image(Asset.Icon.smiley.name)
                         .resizable()
                         .frame(width: 30.0, height: 30.0)
@@ -88,7 +88,7 @@ struct EventContextMenu: View {
             }
             if model.canReply {
                 Button(action: onReply, label: {
-                    Text(L10n.Event.ContextMenu.reply)
+                    Text(verbatim: L10n.Event.ContextMenu.reply)
                     Image(Asset.Icon.Arrow.upLeft.name)
                         .resizable()
                         .frame(width: 30.0, height: 30.0)
@@ -96,7 +96,7 @@ struct EventContextMenu: View {
             }
             if model.canEdit {
                 Button(action: onEdit, label: {
-                    Text(L10n.Event.ContextMenu.edit)
+                    Text(verbatim: L10n.Event.ContextMenu.edit)
                     Image(Asset.Icon.pencil.name)
                         .resizable()
                         .frame(width: 30.0, height: 30.0)
@@ -104,7 +104,7 @@ struct EventContextMenu: View {
             }
             if model.canRedact {
                 Button(action: onRedact, label: {
-                    Text(L10n.Event.ContextMenu.remove)
+                    Text(verbatim: L10n.Event.ContextMenu.remove)
                     Image(Asset.Icon.trash.name)
                         .resizable()
                         .frame(width: 30.0, height: 30.0)

--- a/Nio/Conversations/ContextMenu/ReactionPicker.swift
+++ b/Nio/Conversations/ContextMenu/ReactionPicker.swift
@@ -7,7 +7,7 @@ struct ReactionPicker: View {
 
     var body: some View {
         VStack {
-            Text(L10n.ReactionPicker.title)
+            Text(verbatim: L10n.ReactionPicker.title)
                 .foregroundColor(.gray)
                 .font(.headline)
                 .padding(.bottom, 30)

--- a/Nio/Conversations/Event Views/RedactionEventView.swift
+++ b/Nio/Conversations/Event Views/RedactionEventView.swift
@@ -24,7 +24,7 @@ struct RedactionEventView: View {
                     .font(.caption)
                     .foregroundColor(.gray)
                 if model.reason != nil {
-                    Text(L10n.Event.reason(model.reason!))
+                    Text(verbatim: L10n.Event.reason(model.reason!))
                         .foregroundColor(.gray)
                         .font(.callout)
                 }

--- a/Nio/Conversations/MessageComposerView.swift
+++ b/Nio/Conversations/MessageComposerView.swift
@@ -68,7 +68,7 @@ struct MessageComposerView: View {
                     .background(Color.accentColor)
                 VStack {
                     HStack {
-                        Text(L10n.Composer.editMessage)
+                        Text(verbatim: L10n.Composer.editMessage)
                             .frame(alignment: .leading)
                             .padding(.leading, 10)
                             .foregroundColor(.accentColor)
@@ -78,7 +78,7 @@ struct MessageComposerView: View {
                         }, label: {
                             SFSymbol.close
                                 .font(.system(size: 20))
-                                .accessibility(label: Text(L10n.Composer.AccessibilityLabel.cancelEdit))
+                                .accessibility(label: Text(verbatim: L10n.Composer.AccessibilityLabel.cancelEdit))
                         })
                     }
                     Text(highlightMessage!)
@@ -97,7 +97,7 @@ struct MessageComposerView: View {
             Image(Asset.Icon.paperclip.name)
                 .resizable()
                 .frame(width: 30.0, height: 30.0)
-                .accessibility(label: Text(L10n.Composer.AccessibilityLabel.sendFile))
+                .accessibility(label: Text(verbatim: L10n.Composer.AccessibilityLabel.sendFile))
         })
     }
 
@@ -123,7 +123,7 @@ struct MessageComposerView: View {
             Image(Asset.Icon.paperplane.name)
                 .resizable()
                 .frame(width: 30.0, height: 30.0)
-                .accessibility(label: Text(L10n.Composer.AccessibilityLabel.send))
+                .accessibility(label: Text(verbatim: L10n.Composer.AccessibilityLabel.send))
         })
         .disabled(attributedMessage.isEmpty)
     }

--- a/Nio/Conversations/RecentRoomsView.swift
+++ b/Nio/Conversations/RecentRoomsView.swift
@@ -50,7 +50,7 @@ struct RecentRoomsView: View {
             Image(Asset.Icon.user.name)
                 .resizable()
                 .frame(width: 30.0, height: 30.0)
-                .accessibility(label: Text(L10n.RecentRooms.AccessibilityLabel.settings))
+                .accessibility(label: Text(verbatim: L10n.RecentRooms.AccessibilityLabel.settings))
         })
     }
 
@@ -61,7 +61,7 @@ struct RecentRoomsView: View {
             Image(Asset.Icon.addRoom.name)
                 .resizable()
                 .frame(width: 30.0, height: 30.0)
-                .accessibility(label: Text(L10n.RecentRooms.AccessibilityLabel.newConversation))
+                .accessibility(label: Text(verbatim: L10n.RecentRooms.AccessibilityLabel.newConversation))
         })
     }
 
@@ -144,12 +144,12 @@ struct RoomsListSection: View {
         .alert(isPresented: $showConfirm) {
             Alert(
                 title: Text(onLeaveAlertTitle),
-                message: Text(L10n.RecentRooms.Leave.alertBody(
+                message: Text(verbatim: L10n.RecentRooms.Leave.alertBody(
                     roomToLeave?.summary.displayname
                         ?? roomToLeave?.summary.roomId
                         ?? "")),
                 primaryButton: .destructive(
-                    Text(L10n.Room.Remove.action),
+                    Text(verbatim: L10n.Room.Remove.action),
                     action: {
                         self.leaveRoom()
                 }),

--- a/Nio/Conversations/RoomListItemView.swift
+++ b/Nio/Conversations/RoomListItemView.swift
@@ -127,7 +127,7 @@ struct RoomListItemView: View {
             // Make sure we get enough "breathing air" around the number:
             .padding(.vertical, badgeTextVerticalPadding)
             .padding(.horizontal, 6 * sizeCategory.scalingFactor)
-            .accessibility(label: Text(L10n.RecentRooms.AccessibilityLabel.newMessageBadge(Int(self.badge))))
+            .accessibility(label: Text(verbatim: L10n.RecentRooms.AccessibilityLabel.newMessageBadge(Int(self.badge))))
             .background(
                 GeometryReader { geometry in
                     Capsule()

--- a/Nio/Conversations/RoomView.swift
+++ b/Nio/Conversations/RoomView.swift
@@ -43,10 +43,10 @@ struct RoomContainerView: View {
         .alert(isPresented: $showJoinAlert) {
             let roomName = self.room.summary.displayname ?? self.room.summary.roomId ?? L10n.Room.Invitation.fallbackTitle
             return Alert(
-                title: Text(L10n.Room.Invitation.JoinAlert.title),
-                message: Text(L10n.Room.Invitation.JoinAlert.message(roomName)),
+                title: Text(verbatim: L10n.Room.Invitation.JoinAlert.title),
+                message: Text(verbatim: L10n.Room.Invitation.JoinAlert.message(roomName)),
                 primaryButton: .default(
-                    Text(L10n.Room.Invitation.JoinAlert.joinButton),
+                    Text(verbatim: L10n.Room.Invitation.JoinAlert.joinButton),
                     action: {
                         self.room.room.mxSession.joinRoom(self.room.room.roomId) { _ in
                             self.room.markAllAsRead()
@@ -76,8 +76,8 @@ struct RoomContainerView: View {
 
     var attachmentPickerSheet: ActionSheet {
         ActionSheet(
-            title: Text(L10n.Room.Attachment.selectType), buttons: [
-                .default(Text(L10n.Room.Attachment.typePhoto), action: {
+            title: Text(verbatim: L10n.Room.Attachment.selectType), buttons: [
+                .default(Text(verbatim: L10n.Room.Attachment.typePhoto), action: {
                     self.showImagePicker = true
                 }),
                 .cancel()
@@ -153,9 +153,9 @@ struct RoomView: View {
             }
         }
         .alert(item: $eventToRedact) { eventId in
-            Alert(title: Text(L10n.Room.Remove.title),
-                  message: Text(L10n.Room.Remove.message),
-                  primaryButton: .destructive(Text(L10n.Room.Remove.action), action: { self.onRedact(eventId, nil) }),
+            Alert(title: Text(verbatim: L10n.Room.Remove.title),
+                  message: Text(verbatim: L10n.Room.Remove.message),
+                  primaryButton: .destructive(Text(verbatim: L10n.Room.Remove.action), action: { self.onRedact(eventId, nil) }),
                   secondaryButton: .cancel())
         }
     }

--- a/Nio/RootView.swift
+++ b/Nio/RootView.swift
@@ -26,12 +26,12 @@ struct RootView: View {
             return AnyView(
                 VStack {
                     Spacer()
-                    Text(error.localizedDescription)
+                    Text(verbatim: error.localizedDescription)
                     Spacer()
                     Button(action: {
                         self.store.loginState = .loggedOut
                     }, label: {
-                        Text(L10n.Login.failureBackToLogin)
+                        Text(verbatim: L10n.Login.failureBackToLogin)
                     }).padding()
                 }
             )

--- a/Nio/Settings/SettingsView.swift
+++ b/Nio/Settings/SettingsView.swift
@@ -21,7 +21,7 @@ struct SettingsView: View {
         NavigationView {
             Form {
                 Section {
-                    Picker(selection: $accentColor, label: Text(L10n.Settings.accentColor)) {
+                    Picker(selection: $accentColor, label: Text(verbatim: L10n.Settings.accentColor)) {
                         ForEach(Color.allAccentOptions, id: \.self) { color in
                             HStack {
                                 Circle()
@@ -33,7 +33,7 @@ struct SettingsView: View {
                         }
                     }
 
-                    Picker(selection: $appIconTitle.current, label: Text(L10n.Settings.appIcon)) {
+                    Picker(selection: $appIconTitle.current, label: Text(verbatim: L10n.Settings.appIcon)) {
                         ForEach(AppIconTitle.alternatives) { AppIcon(title: $0) }
                     }
                 }
@@ -42,7 +42,7 @@ struct SettingsView: View {
                     Button(action: {
                         self.logoutAction()
                     }, label: {
-                        Text(L10n.Settings.logOut)
+                        Text(verbatim: L10n.Settings.logOut)
                     })
                 }
             }


### PR DESCRIPTION
When calling `Text(x)`, `x` is being passed through the localization system. Instead do `Text(verbatim: x)` for strings that are localized already, i.e. those coming from the `L10n` enum.