### PR TITLE
Fixes grouped messages padding

### DIFF
--- a/Nio/Conversations/Event Views/EventContainerView.swift
+++ b/Nio/Conversations/Event Views/EventContainerView.swift
@@ -52,11 +52,11 @@ struct EventContainerView: View {
         fileprivate let contextMenuModel: EventContextMenuModel
 
         private var topPadding: CGFloat {
-            connectedEdges.contains(.topEdge) ? 2.0 : 8.0
+            connectedEdges.contains(.topEdge) ? 0.0 : 8.0
         }
 
         private var bottomPadding: CGFloat {
-            connectedEdges.contains(.bottomEdge) ? 2.0 : 8.0
+            connectedEdges.contains(.bottomEdge) ? 0.0 : 8.0
         }
 
         private enum Model {

--- a/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
+++ b/Nio/Conversations/Event Views/MessageView/BorderedMessageView.swift
@@ -68,7 +68,6 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
         .fill(gradient).opacity(0.9)
         // and flip it in case it's meant to be right-aligned:
         .scaleEffect(x: isMe ? -1.0 : 1.0, y: 1.0, anchor: .center)
-        .padding(.bottom, connectedEdges.contains(.bottomEdge) ? -12 : 0)
     }
 
     private var timestampView: some View {
@@ -157,6 +156,8 @@ struct BorderedMessageView<Model>: View where Model: MessageViewModelProtocol {
                 timestampView
             }
         }
+        .padding(.top, model.reactions.count > 0 || !connectedEdges.contains(.bottomEdge) ? -8.0 : 0)
+        .padding(.bottom, model.reactions.count > 0 ? 3.0 : 0)
     }
 }
 

--- a/NioShareExtension/ShareViewController.swift
+++ b/NioShareExtension/ShareViewController.swift
@@ -3,6 +3,7 @@ import Social
 import MobileCoreServices
 import SwiftUI
 import NioKit
+import MatrixSDK
 
 @objc(ShareNavigationController)
 class ShareNavigationController: UIViewController {


### PR DESCRIPTION
My previous [version](https://github.com/niochat/nio/pull/284) was a bit naive and non functional for messages with reactions and messages with a timestamp. Now the grouped messages should work properly.