### PR TITLE
Upgrade from MatrixSDK 0.19.0 to 0.20.14.

### DIFF
--- a/Nio.xcodeproj/project.pbxproj
+++ b/Nio.xcodeproj/project.pbxproj
@@ -2055,7 +2055,7 @@
 			repositoryURL = "https://github.com/niochat/MatrixSDK";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.19.0;
+				minimumVersion = 0.20.4;
 			};
 		};
 		CAF2AE9B245DF4B400D84133 /* XCRemoteSwiftPackageReference "CommonMarkAttributedString" */ = {

--- a/Nio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/niochat/MatrixSDK",
         "state": {
           "branch": null,
-          "revision": "d53454baff7fa9a6a50bf5e68bab531049a7e5af",
-          "version": "0.19.0"
+          "revision": "faab7d8d55910f40589111caf9392d67c24889a9",
+          "version": "0.20.14"
         }
       },
       {

--- a/NioKit/Models/NIORoom.swift
+++ b/NioKit/Models/NIORoom.swift
@@ -16,7 +16,7 @@ public struct RoomItem: Codable, Hashable {
     public init(room: MXRoom) {
         self.roomId = room.summary.roomId
         self.displayName = room.summary.displayname ?? ""
-        self.messageDate = room.summary.lastMessageOriginServerTs
+        self.messageDate = room.summary.lastMessage.originServerTs
     }
 }
 
@@ -128,6 +128,7 @@ public class NIORoom: ObservableObject {
             size: image.size,
             mimeType: "image/jpeg",
             thumbnail: image,
+            blurhash: nil,
             localEcho: &localEcho
         ) { _ in
             self.objectWillChange.send()    // localEcho.sentState has(!) changed

--- a/NioKit/Models/NIORoomSummary.swift
+++ b/NioKit/Models/NIORoomSummary.swift
@@ -6,7 +6,7 @@ public class NIORoomSummary: ObservableObject {
     internal var summary: MXRoomSummary
 
     public var lastMessageDate: Date {
-        let timestamp = Double(summary.lastMessageOriginServerTs)
+        let timestamp = Double(summary.lastMessage.originServerTs)
         return Date(timeIntervalSince1970: timestamp / 1000)
     }
 


### PR DESCRIPTION
Upgrades MatrixSDK to the version that fixed the recent [security advisory](https://github.com/matrix-org/matrix-ios-sdk/security/advisories/GHSA-fxvm-7vhj-wj98). There have probably been a lot of changes since 0.19.0 and I haven't tested this much more than loading a few rooms, but seems like now is as good a time as any to upgrade to the (almost) latest version of the SDK.